### PR TITLE
Benf/feature/obc_iris_handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,6 @@ members = [
     "ex3_shared_libs/interfaces/ipc", 
     "ex3_obc_fsw/dev_tools/ipc_server_dev_tool",
     "ex3_shared_libs/logging",
+    "ex3_obc_fsw/handlers/iris_handler",
 ]
+

--- a/ex3_obc_fsw/handlers/iris_handler/Cargo.toml
+++ b/ex3_obc_fsw/handlers/iris_handler/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "iris_handler"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tcp_interface = { path = "../../../ex3_shared_libs/tcp_interface" }
+ipc_interface = { path = "../../../ex3_shared_libs/ipc_interface" }
+common = {path = "../../../ex3_shared_libs/common"}
+nix = "0.26.2"
+message_structure = { path = "../../../ex3_shared_libs/message_structure" }

--- a/ex3_obc_fsw/handlers/iris_handler/README.md
+++ b/ex3_obc_fsw/handlers/iris_handler/README.md
@@ -7,10 +7,30 @@ To run this handler properly run the uplink script located in ex3_software/scrip
 Contains one interface for communication with the simulated IRIS over TCP and a second interface for Unix domain sockets that are used for internal communication. The TCP interface is created on the port specified in common::ports for the simulated environment. 
 
 The handler takes the opcode and arguements sent and translates them to the format the simulated IRIS subsystem expects. It then receives and parses the response from the IRIS subsystem, images are saved at the location specified by IRIS_DATA_PATH, other commands expect relatively minor responses and are printed directly to the terminal. 
-There are currently 10 opcodes programmed, detailed in-depth within the simulated subsystems IRIS README.md. The main ones are **1** to turn the camera sensor on/off, **0** to capture an image and **2** to fetch images.
+There are currently 10 opcodes programmed, detailed in-depth within the simulated subsystems IRIS repository, currently located [here] (https://github.com/AlbertaSat/ex3_simulated_subsystems/tree/main/IRIS). The main ones are **1** to turn the camera sensor on/off, **0** to capture an image and **2** to fetch images.
 
 ### Run and Testing
 Currently there is not a defined way to run the program by itself. It requires at minimum the simulated Iris subsystem running as well as message dispatcher. However, it is easier to just run the uplink script and specify the IRIS subsystem at the ground station terminal.
 
-1. Run the uplink script, details on how to run it are located in the main README for this repository
+1. Run the uplink script, details on how to run it are located in the [here](../../../README.md)
 2. To send commands to the handler, locate the ground station terminal and type ```IRIS <opcode> <arg1> <arg2>...``` the number of arguements required depend on the command.
+
+An example of the main 3 commands, there are currently 10 opcodes available, some with parameters such as opcode 1 and 2, others with no parameters such as opcode 0:
+```bash
+Ex3 CLI GS > IRIS 1 1 # Turns IRIS sensor on
+Built msg: Msg { header: MsgHeader { msg_len: 6, msg_id: 0, dest_id: 4, source_id: 7, op_code: 1 }, msg_body: [1] }
+Sent 6 bytes to Coms handler
+Received ACK: Msg { header: MsgHeader { msg_len: 7, msg_id: 0, dest_id: 7, source_id: 8, op_code: 200 }, msg_body: [79, 75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+
+Ex3 CLI GS > IRIS 0 # Take a picture
+Built msg: Msg { header: MsgHeader { msg_len: 5, msg_id: 0, dest_id: 4, source_id: 7, op_code: 0 }, msg_body: [] }
+Sent 5 bytes to Coms handler
+Received ACK: Msg { header: MsgHeader { msg_len: 7, msg_id: 0, dest_id: 7, source_id: 8, op_code: 200 }, msg_body: [79, 75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+
+Ex3 CLI GS > IRIS 2 1 # Fetch one image
+Built msg: Msg { header: MsgHeader { msg_len: 6, msg_id: 0, dest_id: 4, source_id: 7, op_code: 2 }, msg_body: [1] }
+Sent 6 bytes to Coms handler
+Received ACK: Msg { header: MsgHeader { msg_len: 7, msg_id: 0, dest_id: 7, source_id: 8, op_code: 200 }, msg_body: [79, 75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+
+Ex3 CLI GS > 
+```

--- a/ex3_obc_fsw/handlers/iris_handler/README.md
+++ b/ex3_obc_fsw/handlers/iris_handler/README.md
@@ -7,7 +7,7 @@ To run this handler properly run the uplink script located in ex3_software/scrip
 Contains one interface for communication with the simulated IRIS over TCP and a second interface for Unix domain sockets that are used for internal communication. The TCP interface is created on the port specified in common::ports for the simulated environment. 
 
 The handler takes the opcode and arguements sent and translates them to the format the simulated IRIS subsystem expects. It then receives and parses the response from the IRIS subsystem, images are saved at the location specified by IRIS_DATA_PATH, other commands expect relatively minor responses and are printed directly to the terminal. 
-There are currently 10 opcodes programmed, detailed in-depth within the simulated subsystems IRIS repository, currently located [here] (https://github.com/AlbertaSat/ex3_simulated_subsystems/tree/main/IRIS). The main ones are **1** to turn the camera sensor on/off, **0** to capture an image and **2** to fetch images.
+There are currently 10 opcodes programmed, detailed in-depth within the simulated subsystems IRIS repository, currently located [here](https://github.com/AlbertaSat/ex3_simulated_subsystems/tree/main/IRIS). The main ones are **1** to turn the camera sensor on/off, **0** to capture an image and **2** to fetch images.
 
 ### Run and Testing
 Currently there is not a defined way to run the program by itself. It requires at minimum the simulated Iris subsystem running as well as message dispatcher. However, it is easier to just run the uplink script and specify the IRIS subsystem at the ground station terminal.
@@ -15,7 +15,7 @@ Currently there is not a defined way to run the program by itself. It requires a
 1. Run the uplink script, details on how to run it are located in the [here](../../../README.md)
 2. To send commands to the handler, locate the ground station terminal and type ```IRIS <opcode> <arg1> <arg2>...``` the number of arguements required depend on the command.
 
-An example of the main 3 commands, there are currently 10 opcodes available, some with parameters such as opcode 1 and 2, others with no parameters such as opcode 0:
+An example of the main 3 commands; there are currently 10 opcodes available, some with parameters such as opcode 1 and 2, others with no parameters such as opcode 0:
 ```bash
 Ex3 CLI GS > IRIS 1 1 # Turns IRIS sensor on
 Built msg: Msg { header: MsgHeader { msg_len: 6, msg_id: 0, dest_id: 4, source_id: 7, op_code: 1 }, msg_body: [1] }

--- a/ex3_obc_fsw/handlers/iris_handler/README.md
+++ b/ex3_obc_fsw/handlers/iris_handler/README.md
@@ -1,0 +1,16 @@
+# IRIS Handler
+
+To run this handler properly run the uplink script located in ex3_software/scripts/
+
+**Must have simulated IRIS running to process commands**
+
+Contains one interface for communication with the simulated IRIS over TCP and a second interface for Unix domain sockets that are used for internal communication. The TCP interface is created on the port specified in common::ports for the simulated environment. 
+
+The handler takes the opcode and arguements sent and translates them to the format the simulated IRIS subsystem expects. It then receives and parses the response from the IRIS subsystem, images are saved at the location specified by IRIS_DATA_PATH, other commands expect relatively minor responses and are printed directly to the terminal. 
+There are currently 10 opcodes programmed, detailed in-depth within the simulated subsystems IRIS README.md. The main ones are **1** to turn the camera sensor on/off, **0** to capture an image and **2** to fetch images.
+
+### Run and Testing
+Currently there is not a defined way to run the program by itself. It requires at minimum the simulated Iris subsystem running as well as message dispatcher. However, it is easier to just run the uplink script and specify the IRIS subsystem at the ground station terminal.
+
+1. Run the uplink script, details on how to run it are located in the main README for this repository
+2. To send commands to the handler, locate the ground station terminal and type ```IRIS <opcode> <arg1> <arg2>...``` the number of arguements required depend on the command.

--- a/ex3_obc_fsw/handlers/iris_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/iris_handler/src/main.rs
@@ -72,12 +72,12 @@ impl IRISHandler {
 
     fn handle_msg_for_iris(&mut self, msg: Msg){
         
-        let (command_msg, success) = match msg.header.op_code {
-            opcodes::iris::RESET=> {
+        let (command_msg, success) = match opcodes::IRIS::from(msg.header.op_code) {
+            opcodes::IRIS::Reset=> {
                 ("RST", true)
             }
             // Image commands
-            opcodes::iris::TOGGLE_SENSOR=> {
+            opcodes::IRIS::ToggleSensor=> {
                 if msg.msg_body[0] == 1 {
                     ("ON", true)
                 } else if msg.msg_body[0] == 0 {
@@ -86,35 +86,35 @@ impl IRISHandler {
                     ("Error: invalid msg body for opcode 1", false)
                 }
             }
-            opcodes::iris::CAPTURE_IMAGE=> {
+            opcodes::IRIS::CaptureImage=> {
                 ("TKI", true)
             }
-            opcodes::iris::FETCH_IMAGE=> {
+            opcodes::IRIS::FetchImage=> {
                 // Assumes that there are not more than 255 images being request at any one time
                 (&*format!("FTI:{}", msg.msg_body[0]),true)
             }
-            opcodes::iris::GET_IMAGE_SIZE=> {
+            opcodes::IRIS::GetImageSize=> {
                 // Currently can only access the first 255 images stored on IRIS, will be updated if needed
                 (&*format!("FSI:{}", msg.msg_body[0]),true)
             }
-            opcodes::iris::GET_N_IMAGES_AVAILABLE=> {
+            opcodes::IRIS::GetNImagesAvailable=> {
                 ("FNI", true)
             }
-            opcodes::iris::DEL_IMAGE=> {
+            opcodes::IRIS::DelImage=> {
                 (&*format!("DTI:{}", msg.msg_body[0]),true)
             }
             // Housekeeping commands
-            opcodes::iris::GET_TIME=> {
+            opcodes::IRIS::GetTime=> {
                 ("FTT", true)
             }
-            opcodes::iris::SET_TIME=> {
+            opcodes::IRIS::SetTime=> {
                 // Placeholder for reading the total time need to determine how we will handle >255 values (ie. epoch time)
                 (&*format!("STT:{}", msg.msg_body[0]),true)
             }
-            opcodes::iris::GET_HK=> {
+            opcodes::IRIS::GetHK=> {
                 ("FTH", true)
             }
-            _ => {
+            opcodes::IRIS::Error => {
                 (&*format!("Opcode {} not found for IRIS", msg.header.op_code), false)
                 
             }

--- a/ex3_obc_fsw/handlers/iris_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/iris_handler/src/main.rs
@@ -1,0 +1,168 @@
+/*
+Written By Ben Fisher, extreme referencing from Devin Headrick's work
+Summer 2024
+
+IRIS is a subsystem that is responsible for imaging the surface of the planet at schedulable times. It can store
+images onboard and the OBC can then fetch these images from the IRIS to send to the ground station. The IRIS subsystem
+should be completely controlled via the FSW, it does not ouput data except when asked. The handler receives commands
+from the OBC receiver who receives commands from the groundstation via UHF. It may be that certain commands from the OBC 
+require multiple commands on the IRIS to activate, the handler should recognize this.
+
+
+TODO - implement iris handler and interfacing (need to figure out how)
+
+TODO - If connection is lost with an interface, attempt to reconnect every 5 seconds
+TOOD - Figure out way to use polymorphism and have the interfaces be configurable at runtime (i.e. TCP, UART, etc.)
+TODO - Get state variables from a state manager (channels?) upon instantiation and update them as needed.
+TODO - Setup a way to handle opcodes from messages passed to the handler
+
+
+*/
+
+use common::{opcodes, ports};
+use ipc_interface::read_socket;
+use ipc_interface::IPCInterface;
+use message_structure::*;
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use std::io::Error;
+use std::io::ErrorKind;
+use tcp_interface::*;
+
+const IRIS_DATA_DIR_PATH: &str = "iris_data";
+const IRIS_PACKET_SIZE: usize = 1252;
+const IRIS_INTERFACE_BUFFER_SIZE: usize = IRIS_PACKET_SIZE;
+
+/// Opcodes for messages relating to IRIS functionality
+// pub enum OpCode {
+
+// }
+
+/// Interfaces are option types incase they are not properly created upon running this handler, so the program does not panic
+struct IRISHandler {
+    toggle_sensor: bool,
+    peripheral_interface: Option<TcpInterface>, // For communication with the IRIS peripheral [external to OBC]. Will be dynamic
+    dispatcher_interface: Option<IPCInterface>, // For communcation with other FSW components [internal to OBC] (i.e. message dispatcher)
+}
+
+impl IRISHandler {
+    pub fn new(
+        iris_interface: Result<TcpInterface, std::io::Error>,
+        dispatcher_interface: Result<IPCInterface, std::io::Error>,
+    ) -> IRISHandler {
+        //if either interfaces are error, print this
+        if iris_interface.is_err() {
+            println!(
+                "Error creating IRIS interface: {:?}",
+                iris_interface.as_ref().err().unwrap()
+            );
+        }
+        if dispatcher_interface.is_err() {
+            println!(
+                "Error creating dispatcher interface: {:?}",
+                dispatcher_interface.as_ref().err().unwrap()
+            );
+        }
+
+        IRISHandler {
+            toggle_sensor: false,
+            peripheral_interface: iris_interface.ok(),
+            dispatcher_interface: dispatcher_interface.ok(),
+        }
+    }
+
+    fn handle_msg_for_iris(&mut self, msg: Msg) -> Result<(), Error> {
+        match msg.header.op_code {
+            opcodes::iris::TOGGLE_SENSOR=> {
+                if msg.msg_body[0] == 0 {
+                    self.toggle_sensor = false;
+                    Ok(())
+                } else if msg.msg_body[0] == 1 {
+                    self.toggle_sensor = true;
+                    Ok(())
+                } else {
+                    eprintln!("Error: invalid msg body for opcode 0");
+                    Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "Invalid msg body for opcode 0 on IRIS",
+                    ))
+                }
+            }
+            _ => {
+                eprintln!("Error: invalid msg body for opcode 0");
+                Err(Error::new(
+                    ErrorKind::NotFound,
+                    format!("Opcode {} not found for IRIS", msg.header.op_code),
+                ))
+            }
+        }
+    }
+    // Sets up threads for reading and writing to its interaces, and sets up channels for communication between threads and the handler
+    pub fn run(&mut self) -> std::io::Result<()> {
+        // Read and poll for input for a message
+        let mut socket_buf = vec![0u8; IRIS_INTERFACE_BUFFER_SIZE];
+        loop {
+            if let Ok(n) = read_socket(
+                self.dispatcher_interface.clone().unwrap().fd,
+                &mut socket_buf,
+            ) {
+                if n > 0 {
+                    let recv_msg: Msg = deserialize_msg(&socket_buf).unwrap();
+                    self.handle_msg_for_iris(recv_msg)?;
+                    println!("Data toggle set to {}", self.toggle_sensor);
+                    socket_buf.flush()?;
+                }
+            }
+            if self.toggle_sensor == true {
+                // TODO: Swap out dfgm code for IRIS code
+                let mut tcp_buf = [0u8; BUFFER_SIZE];
+                let status = TcpInterface::read(
+                    &mut self.peripheral_interface.as_mut().unwrap(),
+                    &mut tcp_buf,
+                );
+                match status {
+                    Ok(data_len) => {
+                        println!("Got data {:?}", tcp_buf);
+                        store_iris_data(&tcp_buf)?;
+                    }
+                    Err(e) => {
+                        println!("Error: {}", e);
+                    }
+                }
+            }
+        }
+    }
+
+    //TODO - Convert bytestream into message struct
+    //TODO - After receiving the message, send a response back to the dispatcher
+    //TODO - handle the message based on its opcode
+}
+
+/// Write IRIS data to a file (for now --- this may changer later if we use a db or other storage)
+/// Later on we likely want to specify a path to specific storage medium (sd card 1 or 2)
+/// We may also want to implement something generic to handle 'payload data' storage so we can have it duplicated, stored in multiple locations, or compressed etc.
+fn store_iris_data(data: &[u8]) -> std::io::Result<()> {
+    std::fs::create_dir_all(IRIS_DATA_DIR_PATH)?;
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(format!("{}/data", IRIS_DATA_DIR_PATH))?;
+    file.write_all(data)?;
+    Ok(())
+}
+
+fn main() {
+    println!("Beginning IRIS Handler...");
+    //For now interfaces are created and if their associated ports are not open, they will be ignored rather than causing the program to panic
+
+    //Create TCP interface for IRIS handler to talk to simulated IRIS
+    let iris_interface = TcpInterface::new_client("127.0.0.1".to_string(), ports::SIM_IRIS_PORT);
+
+    //Create TCP interface for IRIS handler to talk to message dispatcher
+    let dispatcher_interface = IPCInterface::new("iris_handler".to_string());
+
+    //Create IRIS handler
+    let mut iris_handler = IRISHandler::new(iris_interface, dispatcher_interface);
+
+    iris_handler.run();
+}

--- a/ex3_obc_fsw/msg_dispatcher/msg_dispatcher.c
+++ b/ex3_obc_fsw/msg_dispatcher/msg_dispatcher.c
@@ -24,13 +24,14 @@ int main(int argc, char *argv[])
     int ret = 0;                      // used for assessing returns of various fxn calls
     int ready;                        // how many fd are ready from the poll (have return event)
 
-    int num_components = 3;
+    int num_components = 4;
+    ComponentStruct *iris_handler = component_factory("iris_handler", IRIS);
     ComponentStruct *dfgm_handler = component_factory("dfgm_handler", DFGM);
     ComponentStruct *coms_handler = component_factory("coms_handler", COMS);
     ComponentStruct *test_handler = component_factory("test_handler", TEST);
 
     // Array of pointers to components the message dispatcher interacts with
-    ComponentStruct *components[3] = {dfgm_handler, coms_handler, test_handler};
+    ComponentStruct *components[4] = {dfgm_handler, coms_handler, iris_handler, test_handler};
 
     nfds_t nfds = (unsigned long int)num_components; // num of fds we are polling
     struct pollfd *pfds;                             // fd we are polling

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -168,10 +168,9 @@ pub mod opcodes {
         pub const GET_N_IMAGES_AVAILABLE: u8 = 4;
         pub const SET_TIME: u8 = 5;
         pub const GET_TIME: u8 = 6;
-        pub const SET_CONFIGS: u8 = 7;
-        pub const GET_CONFIGS: u8 = 8;
-        pub const RESET: u8 = 9;
-        pub const GET_IMAGE_SIZE: u8 = 10;
+        pub const RESET: u8 = 7;
+        pub const DEL_IMAGE: u8 = 8;
+        pub const GET_IMAGE_SIZE: u8 = 9;
 
     }
 }

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -160,6 +160,20 @@ pub mod opcodes {
             }
         }
     }
+    pub mod iris {
+        pub const CAPTURE_IMAGE: u8 = 0;
+        pub const TOGGLE_SENSOR: u8 = 1;
+        pub const FETCH_IMAGE: u8 = 2;
+        pub const GET_HK: u8 = 3;
+        pub const GET_N_IMAGES_AVAILABLE: u8 = 4;
+        pub const SET_TIME: u8 = 5;
+        pub const GET_TIME: u8 = 6;
+        pub const SET_CONFIGS: u8 = 7;
+        pub const GET_CONFIGS: u8 = 8;
+        pub const RESET: u8 = 9;
+        pub const GET_IMAGE_SIZE: u8 = 10;
+
+    }
 }
 
 #[cfg(test)]

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -142,6 +142,41 @@ pub mod opcodes {
         pub const GET_DFGM_DATA: u8 = 1;
     }
 
+    // For IRIS subsystem
+    pub enum IRIS {
+        CaptureImage = 0,
+        ToggleSensor = 1,
+        FetchImage = 2,
+        GetHK = 3,
+        GetNImagesAvailable = 4,
+        SetTime = 5,
+        GetTime = 6,
+        Reset = 7,
+        DelImage = 8,
+        GetImageSize = 9,
+        Error = 99,
+
+    }
+    impl From<u8> for IRIS {
+        fn from(value: u8) -> Self {
+            match value {
+                0 => IRIS::CaptureImage,
+                1 => IRIS::ToggleSensor,
+                2 => IRIS::FetchImage,
+                3 => IRIS::GetHK,
+                4 => IRIS::GetNImagesAvailable,
+                5 => IRIS::SetTime,
+                6 => IRIS::GetTime,
+                7 => IRIS::Reset,
+                8 => IRIS::DelImage,
+                9 => IRIS::GetImageSize,
+                _ => {
+                    IRIS::Error // or choose a default value or handle the error in a different way
+                }
+            }
+        }
+    }
+
     // For dummy subsystem - used in testing and development
     pub enum DUMMY {
         SetDummyVariable = 0,
@@ -159,19 +194,6 @@ pub mod opcodes {
                 }
             }
         }
-    }
-    pub mod iris {
-        pub const CAPTURE_IMAGE: u8 = 0;
-        pub const TOGGLE_SENSOR: u8 = 1;
-        pub const FETCH_IMAGE: u8 = 2;
-        pub const GET_HK: u8 = 3;
-        pub const GET_N_IMAGES_AVAILABLE: u8 = 4;
-        pub const SET_TIME: u8 = 5;
-        pub const GET_TIME: u8 = 6;
-        pub const RESET: u8 = 7;
-        pub const DEL_IMAGE: u8 = 8;
-        pub const GET_IMAGE_SIZE: u8 = 9;
-
     }
 }
 

--- a/scripts/IRIS_uplink_command_msg.sh
+++ b/scripts/IRIS_uplink_command_msg.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+# Written by Devin Headrick 
+# Edited by Ben Fisher
+# Summer 2024
+
+# User must provide the path to the simulated subsystem directory on their machine as the first arg
+PATH_TO_SIM_SUBS=$1
+
+if [ "$#" -lt 1 ]; then
+    echo "ERROR=> Requires argument: <path to sim subsystem dir>\n"
+    exit 0
+fi;
+echo "Path being used to sim subs: $PATH_TO_SIM_SUBS"
+
+## Launch the GS simulation (this can just be a tcp server for now )
+gnome-terminal -t SIM_GS -- sh -c 'cd ../ && cargo run --bin cli_ground_station; bash exec'
+
+## Create the IRIS simulated subystem components because they are tcp servers  
+gnome-terminal -t SIM_IRIS_SUBSYSTEM -- sh -c "cd $PATH_TO_SIM_SUBS/IRIS && python3 ./iris_simulated_server.py ; bash exec;"
+# For now the UHF transceiver is bypassed and the GS sends msgs directly to the coms handler 
+
+# ## Create the msg dispatcher (first component of the obc fsw because it creates ipc servers 
+gnome-terminal -t MSG_DISPATCHER -- sh -c 'cd ../ex3_obc_fsw/msg_dispatcher && make && ./msg_dispatcher; exec bash'
+sleep 0.25
+
+# ## Create the hanlders and other obc fsw components (coms handler, dfgm handler, etc. )
+gnome-terminal -t COMS_HANDLER -- sh -c 'cd ../ && cargo run --bin coms_handler; exec bash'
+gnome-terminal -t IRIS_HANDLER -- sh -c 'cd ../ && cargo run --bin iris_handler; exec bash'

--- a/scripts/uplink_command_msg.sh
+++ b/scripts/uplink_command_msg.sh
@@ -16,12 +16,14 @@ gnome-terminal -t SIM_GS -- sh -c 'cd ../ && cargo run --bin cli_ground_station;
 
 ## Create the simulated subystem components (dfgm and uhf transciever) - because they are tcp servers  
 gnome-terminal -t SIM_DFGM_SUBSYSTEM -- sh -c "cd $PATH_TO_SIM_SUBS/DFGM && python3 ./dfgm_subsystem.py ; bash exec;"
+gnome-terminal -t SIM_IRIS_SUBSYSTEM -- sh -c "cd $PATH_TO_SIM_SUBS/IRIS && python3 ./iris_simulated_server.py ; bash exec;"
 # For now the UHF transceiver is bypassed and the GS sends msgs directly to the coms handler 
 
 # ## Create the msg dispatcher (first component of the obc fsw because it creates ipc servers 
 gnome-terminal -t MSG_DISPATCHER -- sh -c 'cd ../ex3_obc_fsw/msg_dispatcher && make && ./msg_dispatcher; exec bash'
 sleep 0.25
 
-# ## Create the hanlders and other obc fsw components (coms handler, dfgm handler )
+# ## Create the hanlders and other obc fsw components (coms handler, dfgm handler, etc. )
 gnome-terminal -t DFGM_HANDLER -- sh -c 'cd ../ && cargo run --bin dfgm_handler; exec bash'
 gnome-terminal -t COMS_HANDLER -- sh -c 'cd ../ && cargo run --bin coms_handler; exec bash'
+gnome-terminal -t IRIS_HANDLER -- sh -c 'cd ../ && cargo run --bin iris_handler; exec bash'


### PR DESCRIPTION
Created the IRIS handler framework. Currently saves images to a file and does nothing after that, all other commands have output printed directly to the terminal.

Currently opcodes 0-9 are implemented, opcodes 10 and 11 lack sufficient information to know what to expect and have not been written. All opcodes are numbered based off the EX3-SF Software master spreadsheet.

The handler will fail to connect to the current simulated iris subsystem in the main simulated subsystems repository, this is because the port is different on the simulated subsystem compared to the common port. A PR has been made in that repository, those changes need to be implemented for this handler to operate properly.