### PR TITLE
Rowan/feature/implement cli gs bulk protocol

### DIFF
--- a/ex3_ground_station/cli_ground_station/src/main.rs
+++ b/ex3_ground_station/cli_ground_station/src/main.rs
@@ -92,15 +92,14 @@ fn build_msg_from_operator_input(operator_str: String) -> Result<Msg, std::io::E
         if opcode == GET_DFGM_DATA {
             dest_id = ComponentIds::BULK_MSG_DISPATCHER as u8;
             msg_type = MsgType::Bulk as u8;
-            let body = "DFGM DATA".as_bytes();
-            msg_body.extend(body);
+            msg_body = "../handlers/dfgm_handler/dfgm_data".as_bytes().to_vec();
         }
     } else {
         for data_byte in operator_str_split[2..].into_iter() {
         msg_body.push(data_byte.parse::<u8>().unwrap());
         }
     }
-    let msg = Msg::new(0, 0, dest_id, GS, opcode, msg_body);
+    let msg = Msg::new(msg_type, 0, dest_id, GS, opcode, msg_body);
     println!("Built msg: {:?}", msg);
     Ok(msg)
 }

--- a/ex3_ground_station/cli_ground_station/src/main.rs
+++ b/ex3_ground_station/cli_ground_station/src/main.rs
@@ -85,11 +85,13 @@ fn build_msg_from_operator_input(operator_str: String) -> Result<Msg, std::io::E
     let mut dest_id = ComponentIds::from_str(operator_str_split[0]).unwrap() as u8;
     let opcode = operator_str_split[1].parse::<u8>().unwrap();
     let mut msg_body: Vec<u8> = Vec::new();
+    let mut msg_type = 0;
 
     // This is for the Bulk Msg Disp to parse and determine the path it needs to use to get the data
     if dest_id == DFGM {
         if opcode == GET_DFGM_DATA {
             dest_id = ComponentIds::BULK_MSG_DISPATCHER as u8;
+            msg_type = MsgType::Bulk as u8;
             let body = "DFGM DATA".as_bytes();
             msg_body.extend(body);
         }

--- a/ex3_obc_fsw/msg_dispatcher/connection.h
+++ b/ex3_obc_fsw/msg_dispatcher/connection.h
@@ -26,6 +26,7 @@ enum ComponentId
     DEPLOYABLES = 6,
     GS = 7,
     COMS = 8,
+    BULK_MSG_DISPATCHER = 9,
     TEST = 99,
 };
 

--- a/ex3_obc_fsw/msg_dispatcher/msg_dispatcher.c
+++ b/ex3_obc_fsw/msg_dispatcher/msg_dispatcher.c
@@ -34,9 +34,10 @@ int main(int argc, char *argv[])
     ComponentStruct *dfgm_handler = component_factory("dfgm_handler", DFGM);
     ComponentStruct *coms_handler = component_factory("coms_handler", COMS);
     ComponentStruct *test_handler = component_factory("test_handler", TEST);
+    ComponentStruct *bulk_dispatcher = component_factory("bulk_disp", BULK_MSG_DISPATCHER);
 
     // Array of pointers to components the message dispatcher interacts with
-    ComponentStruct *components[4] = {dfgm_handler, coms_handler, iris_handler, test_handler};
+    ComponentStruct *components[5] = {dfgm_handler, coms_handler, iris_handler, bulk_dispatcher ,test_handler};
 
     nfds_t nfds = (unsigned long int)num_components; // num of fds we are polling
     struct pollfd *pfds;                             // fd we are polling

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -42,6 +42,7 @@ pub mod component_ids {
         //...
         GS = 7,
         COMS = 8,
+        BULK_MSG_DISPATCHER = 9,
         //..
         //..
         DUMMY = 99,
@@ -58,6 +59,7 @@ pub mod component_ids {
                 ComponentIds::GPS => write!(f, "GPS"),
                 ComponentIds::GS => write!(f, "GS"),
                 ComponentIds::COMS => write!(f, "COMS"),
+                ComponentIds::BULK_MSG_DISPATCHER => write!(f, "BULK_MSG_DISPATCHER"),
                 ComponentIds::DUMMY => write!(f, "DUMMY"),
             }
         }
@@ -74,6 +76,7 @@ pub mod component_ids {
                 "GPS" => Ok(ComponentIds::GPS),
                 "GS" => Ok(ComponentIds::GS),
                 "COMS" => Ok(ComponentIds::COMS),
+                "BULK_MSG_DISPATCHER" => Ok(ComponentIds::BULK_MSG_DISPATCHER),
                 //...
                 "DUMMY" => Ok(ComponentIds::DUMMY),
                 _ => Err(()),
@@ -94,6 +97,7 @@ pub mod component_ids {
                 5 => ComponentIds::GPS,
                 7 => ComponentIds::GS,
                 8 => ComponentIds::COMS,
+                9 => ComponentIds::BULK_MSG_DISPATCHER,
                 //...
                 99 => ComponentIds::DUMMY,
                 _ => {
@@ -116,6 +120,7 @@ pub mod component_ids {
                 //...
                 ComponentIds::GS => 7,
                 ComponentIds::COMS => 8,
+                ComponentIds::BULK_MSG_DISPATCHER => 9,
                 //...
                 ComponentIds::DUMMY => 99,
             }


### PR DESCRIPTION
This update to the flow of data changes where the bulk_msg_disp gets the path it reads bytes from. Instead of the handler sending the path, the GS builds the msg with the path hard-coded then sends it directly to the bulk_msg_dispatcher. The handler is no long involved in downlinking bulk data. 