### PR TITLE
Shell Handler functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,9 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-# Vim swap files
+# Vim files
 .*.swp
+Session.vim
 
 # Used by editors to jump to definitions
 tags

--- a/ex3_ground_station/cli_ground_station/src/main.rs
+++ b/ex3_ground_station/cli_ground_station/src/main.rs
@@ -86,9 +86,7 @@ fn build_msg_from_operator_input(operator_str: String) -> Result<Msg, std::io::E
     } else {
         opcode = operator_str_split[1].parse::<u8>().unwrap();
 
-        for data_byte in operator_str_split[2..].iter() {
-        msg_body.push(data_byte.parse::<u8>().unwrap());
-        }
+        msg_body.extend(operator_str_split[2..].join(" ").bytes());
     }
     
     let msg = Msg::new(msg_type, 0, dest_id, component_ids::ComponentIds::GS as u8, opcode, msg_body);
@@ -318,7 +316,7 @@ async fn main() {
                     );
                     
                 }
-                println!("Received Data: {:?}", read_buf);
+                println!("Received Message: {:?}, body {:?} = {}", recvd_msg.header, recvd_msg.msg_body,String::from_utf8(recvd_msg.msg_body.clone()).unwrap());
             } else {
                 // Deallocate memory of these messages. Reconstructed version 
                 // has been written to a file. This is slightly slower than .clear() though

--- a/ex3_obc_fsw/dev_tools/ipc_server_dev_tool/src/main.rs
+++ b/ex3_obc_fsw/dev_tools/ipc_server_dev_tool/src/main.rs
@@ -27,14 +27,14 @@ fn handle_user_input(read_data: &[u8], ipc_server: &mut IpcServer) {
             //write first hardcoded msg to ipc client
             let msg = CmdMsg::new(1, ComponentIds::SHELL as u8, 3, 0, vec![5, 6, 7, 8, 9, 10]);
             let serialized_msg = CmdMsg::serialize_to_bytes(&msg).unwrap();
-            ipc_write(&ipc_server.data_fd.as_ref().unwrap(), serialized_msg.as_slice())
+            ipc_write(ipc_server.data_fd.as_ref().unwrap(), serialized_msg.as_slice())
         }
         '2' => {
             println!("Sending msg 2");
             //write first hardcoded msg to ipc client
             let msg = CmdMsg::new(2, ComponentIds::SHELL as u8, 3, 1, vec![5, 6, 7, 8, 9, 10]);
             let serialized_msg = CmdMsg::serialize_to_bytes(&msg).unwrap();
-            ipc_write(&ipc_server.data_fd.as_ref().unwrap(), serialized_msg.as_slice())
+            ipc_write(ipc_server.data_fd.as_ref().unwrap(), serialized_msg.as_slice())
         }
         _ => {
             println!("Invalid input");
@@ -86,7 +86,7 @@ fn main() {
         if let Some(bytes_read) = stdin_read_res {
             if bytes_read > 0 {
                 println!("Received user input: {:?}", stdin_buf);
-                handle_user_input(stdin_buf.as_slice(), &mut ipc_server.as_mut().unwrap());
+                handle_user_input(stdin_buf.as_slice(), ipc_server.as_mut().unwrap());
             }
         }
     }

--- a/ex3_obc_fsw/handlers/coms_handler/README.md
+++ b/ex3_obc_fsw/handlers/coms_handler/README.md
@@ -1,6 +1,6 @@
 # Coms Handler
 
-The coms handler is the first and last part of the OBC FSW (aside from the interface the faciliates phsyical communication with the transceiver) for data communicated with the ground station (downlink and uplink).
+The coms handler is the first and last part of the OBC FSW (aside from the interface that facilitates physical communication with the transceiver) for data communicated with the ground station (downlink and uplink).
 
 ## Scope of the Coms handler
 

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -40,10 +40,9 @@ pub mod component_ids {
         DFGM = 3,
         IRIS = 4,
         GPS = 5,
-        GS = 6,
-        COMS = 7,
-        BulkMsgDispatcher = 8,
-        CMD = 9,
+        GS = 7,
+        COMS = 8,
+        BulkMsgDispatcher = 9,
         SHELL = 10,
         LAST = 11,
     }
@@ -60,7 +59,6 @@ pub mod component_ids {
                 ComponentIds::GS => write!(f, "GS"),
                 ComponentIds::COMS => write!(f, "COMS"),
                 ComponentIds::BulkMsgDispatcher => write!(f, "BulkMsgDispatcher"),
-                ComponentIds::CMD => write!(f, "CMD"),
                 ComponentIds::SHELL => write!(f, "SHELL"),
                 ComponentIds::LAST => write!(f, "illegal"),
             }
@@ -80,7 +78,7 @@ pub mod component_ids {
                 "COMS" => Ok(ComponentIds::COMS),
                 "BulkMsgDispatcher" => Ok(ComponentIds::BulkMsgDispatcher),
                 //...
-                "CMD" => Ok(ComponentIds::CMD),
+                "SHELL" => Ok(ComponentIds::SHELL),
                 "LAST" => Err(()),
                 _ => Err(()),
             }
@@ -103,12 +101,12 @@ pub mod component_ids {
                 x if x == ComponentIds::GS as u8 => Ok(ComponentIds::GS),
                 x if x == ComponentIds::COMS as u8 => Ok(ComponentIds::COMS),
                 x if x == ComponentIds::BulkMsgDispatcher as u8 => Ok(ComponentIds::BulkMsgDispatcher),
-                x if x == ComponentIds::CMD as u8 => Ok(ComponentIds::CMD),
+                x if x == ComponentIds::SHELL as u8 => Ok(ComponentIds::SHELL),
                 x if x == ComponentIds::LAST as u8 => Err(()),
                 _ => Err(()),
             }
         }
-    }    
+    }
 }
 
 /// For constants that are used across the entire project
@@ -266,11 +264,14 @@ mod tests {
         let gps = component_ids::ComponentIds::try_from(5).unwrap();
         assert_eq!(gps, component_ids::ComponentIds::GPS);
 
-        let gs = component_ids::ComponentIds::try_from(6).unwrap();
+        let gs = component_ids::ComponentIds::try_from(7).unwrap();
         assert_eq!(gs, component_ids::ComponentIds::GS);
 
-        let coms = component_ids::ComponentIds::try_from(7).unwrap();
+        let coms = component_ids::ComponentIds::try_from(8).unwrap();
         assert_eq!(coms, component_ids::ComponentIds::COMS);
+
+        let shell = component_ids::ComponentIds::try_from(10).unwrap();
+        assert_eq!(shell, component_ids::ComponentIds::SHELL);
 
         let obc = component_ids::ComponentIds::try_from(0).unwrap();
         assert_eq!(obc, component_ids::ComponentIds::OBC);
@@ -298,6 +299,9 @@ mod tests {
 
         let coms = component_ids::ComponentIds::from_str("COMS").unwrap();
         assert_eq!(coms, component_ids::ComponentIds::COMS);
+
+        let shell = component_ids::ComponentIds::from_str("SHELL").unwrap();
+        assert_eq!(shell, component_ids::ComponentIds::SHELL);
 
         let obc = component_ids::ComponentIds::from_str("OBC").unwrap();
         assert_eq!(obc, component_ids::ComponentIds::OBC);

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -114,6 +114,9 @@ pub mod component_ids {
 /// For constants that are used across the entire project
 pub mod constants {
     pub const UHF_MAX_MESSAGE_SIZE_BYTES: u8 = 128;
+
+    // Something up with the slicing makes this number be the size that each packet ends up 128B
+    pub const DONWLINK_MSG_BODY_SIZE: usize = 121; // 128 - 5 (header) - 2 (sequence number)
 }
 
 /// Here opcodes and their associated meaning are defined for each component

--- a/ex3_shared_libs/interfaces/ipc/src/lib.rs
+++ b/ex3_shared_libs/interfaces/ipc/src/lib.rs
@@ -87,13 +87,13 @@ impl IpcClient {
         tmp
     }
 }
-///
+
 pub fn poll_ipc_clients(clients: &mut Vec<&mut Option<IpcClient>>) -> Result<(usize, String), std::io::Error> {
     //Create poll fd instances for each client
     let mut poll_fds: Vec<libc::pollfd> = Vec::new();
     for client in &mut *clients {
         // Poll data_fd for incoming data
-        if let None = client {
+        if client.is_none() {
             return Ok((0,"".to_string()));
         }
         poll_fds.push(libc::pollfd {
@@ -226,13 +226,13 @@ impl IpcServer {
 
 /// Takes a vector of mutable referenced IpcServers and polls them for incoming data
 /// The IpcServers must be mutable because the connected state and data_fd are mutated in the polling loop
-pub fn poll_ipc_server_sockets(servers: &mut Vec<&mut Option<IpcServer>>) {
+pub fn poll_ipc_server_sockets(servers: &mut [&mut Option<IpcServer>]) {
     let mut poll_fds: Vec<libc::pollfd> = Vec::new();
 
     // Add poll descriptors based on the server's connection state
     for server in servers.iter_mut() {
         // Handle case where server is None
-        if let None = server {
+        if server.is_none() {
             return;
         } else if !server.as_ref().unwrap().connected {
             // Poll conn_fd for incoming connections

--- a/ex3_shared_libs/message_structure/src/lib.rs
+++ b/ex3_shared_libs/message_structure/src/lib.rs
@@ -314,9 +314,8 @@ impl Msg {
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<Self, IoError> {
-        let header_bytes = &bytes[0..HEADER_SIZE];
-        let msg_body = bytes[HEADER_SIZE..].to_vec();
-        let header = MsgHeader::from_bytes(header_bytes)?;
+        let header = MsgHeader::from_bytes(&bytes[0..HEADER_SIZE])?;
+        let msg_body = bytes[HEADER_SIZE..header.msg_len as usize].to_vec(); // don't include trailing nulls in body
         Ok(Msg { header, msg_body })
     }
 }


### PR DESCRIPTION
cli_ground_station
    - take a string as the message body coms_handler
    - add server that listens to handler messages and sends to ground_station
    - clear message buffer properly
    - etc. typos, move constant declaration, mark unreachable code
 shell_handler
    - execute command body from ground station and send back stdout
    - add client to talk to gs message server
    - switch to logging instead of println!
Msg
    - use msg_len in MsgHeader to construct message without trailing nulls