### PR TITLE
Drake/feature/groundstation beacon client

### DIFF
--- a/ex3_ground_station/cli_ground_station/src/main.rs
+++ b/ex3_ground_station/cli_ground_station/src/main.rs
@@ -223,7 +223,7 @@ async fn main() {
     let ipaddr = std::env::args().nth(1).unwrap_or("localhost".to_string());
 
     eprintln!("Connecting to UHF channel via TCP at {ipaddr}...");
-
+    // Create tcp client listening to simulated uhf server.
     let mut esat_uhf_interface =
         match TcpInterface::new_client(ipaddr.to_string(), ports::SIM_ESAT_UHF_PORT) {
             Ok(ti) => ti,
@@ -234,7 +234,7 @@ async fn main() {
         };
 
     eprintln!("Connecting to beacon broadcast channel via TCP at {ipaddr}...");
-
+    // Create tcp client listening to simulated uhf beacon server.
     let mut esat_beacon_interface =
         match TcpInterface::new_client(ipaddr.to_string(), ports::SIM_ESAT_BEACON_PORT) {
             Ok(ti) => ti,

--- a/ex3_ground_station/cli_ground_station/src/main.rs
+++ b/ex3_ground_station/cli_ground_station/src/main.rs
@@ -195,6 +195,9 @@ fn process_bulk_messages(bulk_messages: Vec<Msg>, num_bytes: usize) -> Result<Ms
 }
 
 fn beacon_listen(esat_beacon_interface: &mut TcpInterface) {
+    // This function takes a tcp client connected to the simulated uhf's beacon server
+    // it reads the buffer and if it is not empty the contents are deserialized into a message
+    // right now it is just printing the contents of message to stdout.
     let mut buff = [0; 128];
     let bytes_read = match esat_beacon_interface.read(&mut buff) {
         // If we read no bytes just return early
@@ -288,6 +291,7 @@ async fn main() {
                 }
             }
         } else {
+            // Listens on beacon channel for any beacons we get and prints beacon msg to stdout
             beacon_listen(&mut esat_beacon_interface);
 
             let mut read_buf = [0; 128];

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod ports {
     pub const SIM_ESAT_UART_PORT: u16 = 1805;
     pub const SIM_IRIS_PORT: u16 = 1806;
     pub const SIM_ESAT_UHF_PORT: u16 = 1808;
+    pub const SIM_ESAT_BEACON_PORT: u16 = 1809;
 
     pub const DFGM_HANDLER_DISPATCHER_PORT: u16 = 1900;
     pub const SCHEDULER_DISPATCHER_PORT: u16 = 1901;


### PR DESCRIPTION
In this PR I added an additional tcp client in the cli groundstation code to listen exclusively for the Simulated UHF Beacon. It works by listening to a server hosted by the simulated UHF (Different from the servers used to send commands and downlink data). Since I had to implement an additional TCP server in simulated UHF, this PR is dependent on [this](https://github.com/AlbertaSat/ex3_simulated_subsystems/pull/75) pull request in ex3_simulated_subsystems repository. If you want to test this branch please use the simulated subsystem branch mentioned in the PR linked above.

Additionally, I am open to suggestions on what the beacon contents should be (Besides the content that can be manually modified by sending a set beacon command to the UHF handler). @rcunrau mentioned it does not make much sense to have the usual header message for the beacon. Please give me recommendations and I will make the changes before we continue with the review.