### PR TITLE
Refactor of interface code

### DIFF
--- a/ex3_ground_station/cli_ground_station/Cargo.toml
+++ b/ex3_ground_station/cli_ground_station/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 common = { path = "../../ex3_shared_libs/common" }
+interface = { path = "../../ex3_shared_libs/interface" }
 serde_json = "1.0.120"
 chrono = "0.4.38"
 tokio = { version = "1", features = ["full"] }

--- a/ex3_ground_station/cli_ground_station/src/main.rs
+++ b/ex3_ground_station/cli_ground_station/src/main.rs
@@ -19,7 +19,7 @@ use message_structure::*;
 use std::fs::File;
 use std::path::Path;
 use std::str::from_utf8;
-use tcp_interface::*;
+use interface::{tcp::*, Interface};
 
 use libc::{poll, POLLIN};
 use std::fs;

--- a/ex3_obc_fsw/cmd_dispatcher/examples/arduino_uart_test.rs
+++ b/ex3_obc_fsw/cmd_dispatcher/examples/arduino_uart_test.rs
@@ -2,7 +2,7 @@ use std::io::{self, Read};
 use std::panic::panic_any;
 use std::sync::mpsc;
 use std::thread;
-use interface::uart::UARTInterface;
+use interface::{uart::UARTInterface, Interface};
 
 fn main() {
     let mut arduino_serial = UARTInterface::new("/dev/ttyACM2", 9600).unwrap();
@@ -33,7 +33,7 @@ fn main() {
                 println!("Toggling data collection");
                 data_collection = !data_collection;
                 if data_collection {
-                    match arduino_serial.write(&[1]) {
+                    match arduino_serial.send(&[1]) {
                         Ok(_) => {
                             println!("Data collection toggled on.");
                             arduino_serial
@@ -45,7 +45,7 @@ fn main() {
                         }
                     }
                 } else {
-                    match arduino_serial.write(&[0]) {
+                    match arduino_serial.send(&[0]) {
                         Ok(_) => {
                             println!("Data collection toggled off.");
                         }

--- a/ex3_obc_fsw/cmd_dispatcher/examples/i2c_test.rs
+++ b/ex3_obc_fsw/cmd_dispatcher/examples/i2c_test.rs
@@ -1,4 +1,4 @@
-use interface::i2c::*;
+use interface::{i2c::*, Interface};
 use std::{process::exit, thread::sleep, time};
 // Enter I2C bus path here
 const BUS_PATH: &str = "/dev/i2c-0";
@@ -26,7 +26,7 @@ fn main() {
     // Continually read from the device
     let mut buffer: [u8; 2] = [0; 2];
     loop {
-        match lux_meter.read_raw_bytes(&mut buffer) {
+        match lux_meter.read(&mut buffer) {
             Ok(_) => {
                 let result: i16 = (buffer[0] as i16) << 8 | buffer[1] as i16;
                 println!("{}", result);

--- a/ex3_obc_fsw/handlers/adcs_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/adcs_handler/src/main.rs
@@ -9,7 +9,7 @@ TODO: figure out how to cleanly handle errors such as improper inputs
 TODO: get an idea of the actual ADCS commands and figure out a clean way to send commands
 */
 use common::{opcodes, ports};
-use interface::ipc::*;
+use interface::{ipc::*, tcp::*, Interface};
 use log::{debug, trace, warn};
 use common::logging::*;
 use common::message_structure::*;
@@ -17,7 +17,6 @@ use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::io::Error;
 use std::io::ErrorKind;
-use common::tcp_interface::*;
 
 const CMD_DELIMITER: u8 = b":"[0];
 const ADCS_DATA_DIR_PATH: &str = "ex3_obc_fsw/handlers/adcs_handler/adcs_data";

--- a/ex3_obc_fsw/handlers/coms_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/coms_handler/src/main.rs
@@ -15,11 +15,10 @@ use common::component_ids::ComponentIds;
 use common::constants::UHF_MAX_MESSAGE_SIZE_BYTES;
 use common::opcodes;
 use common::ports;
-use interface::ipc::*;
+use interface::{ipc::*, tcp::*, Interface};
 use common::message_structure::{deserialize_msg, serialize_msg, Msg, MsgType};
 use std::os::fd::OwnedFd;
 use std::vec;
-use common::tcp_interface::{Interface, TcpInterface};
 mod uhf_handler;
 use uhf_handler::UHFHandler;
 

--- a/ex3_obc_fsw/handlers/coms_handler/src/uhf_handler.rs
+++ b/ex3_obc_fsw/handlers/coms_handler/src/uhf_handler.rs
@@ -9,7 +9,7 @@ use common::constants::UHF_MAX_MESSAGE_SIZE_BYTES;
 use common::opcodes;
 use log::{debug, trace, warn};
 use common::message_structure::*;
-use common::tcp_interface::{Interface, TcpInterface};
+use interface::{tcp::*, Interface};
 
 // Struct containing UHF parameters to be modified
 pub struct UHFHandler {

--- a/ex3_obc_fsw/handlers/dfgm_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/dfgm_handler/src/main.rs
@@ -16,7 +16,7 @@ TODO - Setup a way to handle opcodes from messages passed to the handler
 use interface::ipc::{poll_ipc_server_sockets, IpcServer, IPC_BUFFER_SIZE};
 
 //use tcp_interface::BUFFER_SIZE;
-use common::tcp_interface::*;
+use interface::{tcp::*, Interface};
 use common::message_structure::*;
 use std::fs::OpenOptions;
 use std::io::prelude::*;

--- a/ex3_obc_fsw/handlers/iris_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/iris_handler/src/main.rs
@@ -23,14 +23,13 @@ use common::logging::*;
 use log::{debug, trace, warn};
 use common::{opcodes, ports, ComponentIds};
 use common::opcodes::IRIS::GetHK;
-use interface::ipc::*;
+use interface::{ipc::*, tcp::*, Interface};
 use common::message_structure::*;
 use std::fs::OpenOptions;
 use std::{io, thread};
 use std::io::prelude::*;
 use std::io::{Error, ErrorKind};
 use std::time::{Instant, Duration};
-use common::tcp_interface::{Interface, TcpInterface};
 use std::collections::HashMap;
 use serde_json::json;
 

--- a/ex3_shared_libs/README.md
+++ b/ex3_shared_libs/README.md
@@ -6,7 +6,6 @@ common: library that is shared between the Ground Station (GS) and the On Board
     - ports: ports used by the payloads for inter-component communication
     - component_ids: definitions of payload IDs
     - message_structure: bulk/cmd/response message formats
-    - tcp_interface: client and server tcp support
     - logging: time-stamped logging facility
 
 interface: library of I/O interface helpers that is shared among the handlers
@@ -14,3 +13,4 @@ interface: library of I/O interface helpers that is shared among the handlers
    - ipc: inter-payload communication client/server support
    - i2c: I2C communication support
    - uart: serial port support
+   - tcp: client and server tcp support

--- a/ex3_shared_libs/common/Cargo.toml
+++ b/ex3_shared_libs/common/Cargo.toml
@@ -10,5 +10,4 @@ strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 log = "0.4.22"
 log4rs = "1.3.0"
-nix = "0.26.2"
 rand = "0.8.5"

--- a/ex3_shared_libs/common/README.md
+++ b/ex3_shared_libs/common/README.md
@@ -1,11 +1,3 @@
-## TCP Interfac
-
-Read and send functions are part of the TcpInterface struct and can be called whenever a process wants to simulate communicating with a peripheral.
-The external handlers which use these interfaces can use these functions to send and receive data to and from the interface asynchronously (non blocking).
-Polling is used to allow for this behaviour.
-
-A TcpInterface is used to faciliate communication between handlers and their associated simulated subsystem. This is to mock the actual connection with real hardware which will be made in the future.
-
 ### Testing
 
 To test the TCP Interface you can enter the following command inside the ex3_shared_libs/interfaces directory. Be sure you have a Tcp server available for connection on the specified port:

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -2,7 +2,6 @@ pub mod component_ids;
 pub use component_ids::{ComponentIds};
 pub mod message_structure;
 pub mod bulk_msg_slicing;
-pub mod tcp_interface;
 pub mod logging;
 
 /// Ports used for communication between handlers and simulated subsystems / payloads

--- a/ex3_shared_libs/interface/Cargo.toml
+++ b/ex3_shared_libs/interface/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nix = { version = "0.29.0", features = ["socket", "fs"] }
+nix = "0.29.0"
 i2cdev = "0.6.1"
 serialport = "4.6.0"
 common = {path = "../common"}

--- a/ex3_shared_libs/interface/Cargo.toml
+++ b/ex3_shared_libs/interface/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nix = "0.29.0"
+nix = { version = "0.29.0", features = ["socket", "fs"] }
 i2cdev = "0.6.1"
 serialport = "4.6.0"
 common = {path = "../common"}

--- a/ex3_shared_libs/interface/README.md
+++ b/ex3_shared_libs/interface/README.md
@@ -1,21 +1,46 @@
 # Interfaces for connecting components
 
-This library provides interfaces which are used by handlers and allow them to communicate with external peripherals, such as subsystems and payloads. 
+This library provides interfaces which are used by handlers and allow them to communicate with external peripherals, such as subsystems and payloads.
 
-## What is this
-
-The `Interface` struct provides methods to initialize a UART connection, and read and write messages using the defined `Msg` format as well as writing and reading raw bytes from devices. This interface is used to communicate with devices onboard the satellite that use UART or other serial connections.
-
-### Features
-
-- Initialize a UART connection with a TTY device path and baud rate.
-- Read messages from the UART interface.
-- Write messages to the UART interface.
+## UART Interface
+This module allows userspace programs to talk with devices via a serial port connection. It implements the Interface trait to send and recieve bytes of data over the serial port connection.
 
 ## I2C Interface
-This library allows userspace programs to communicate with devices via the I2C communication protocol. It includes an I2cDeviceInterface Structure that allows the user to read and write message structures as well as raw bytes over the I2C interface.
+This library allows userspace programs to communicate with devices via the I2C communication protocol. It includes an I2cDeviceInterface Structure that allows the user to read and write raw bytes over the I2C interface.
 
-### Features
-- Constructor to construct the I2C interface.
-- read and send implementation for trait Interface allows user to read and write message structures using I2C interface.
-- read and send function implemented allowing for communication using raw bytes.
+## IPC
+
+This is the libary used by various OBC FSW component to communicate with eachother using IPC Unix Domain Sockets of type SOCKSEQ packet.
+
+The library provides a Server and Client struct, and helper functions to allow the Component using them to poll for incomming connection requests or data.
+
+### Usage
+Other FSW components can use this library by importing it in their Cargo.toml file, and using the new constructors for both Server and Client types to create an assocaited interface.
+
+Client socket inputs are read using the poll_ipc_client_sockets function, which takes a vector of IpcClient objects.
+
+Server socket inputs are read using the poll_ipc_sever_sockets function, which takes a vector of IpcServer objects.
+
+### IMPORTANT
+When data is read the associated buffer of that object is mutated, and thus it is __UP TO THE USER OF THE INTERFACE__ to clear the buffer after they are done reading data from it, before they perform another read.
+
+## TCP Interfac
+Read and send functions are part of the TcpInterface struct and can be called whenever a process wants to simulate communicating with a peripheral.
+The external handlers which use these interfaces can use these functions to send and receive data to and from the interface asynchronously (non blocking).
+Polling is used to allow for this behaviour.
+
+A TcpInterface is used to faciliate communication between handlers and their associated simulated subsystem. This is to mock the actual connection with real hardware which will be made in the future.
+
+### Testing TCP
+To test the TCP Interface you can enter the following command inside the ex3_shared_libs/interfaces directory. Be sure you have a Tcp server available for connection on the specified port:
+
+```@sh
+    cargo test -- --nocapture 
+```
+
+To run a specific test fxn, for example 'test_handler_read', use the following command:
+
+```@sh
+    cargo test tests::test_handler_read -- --exact --nocapture
+```
+

--- a/ex3_shared_libs/interface/src/lib.rs
+++ b/ex3_shared_libs/interface/src/lib.rs
@@ -1,3 +1,14 @@
+use std::io::{Error};
+
 pub mod ipc;
 pub mod i2c;
 pub mod uart;
+pub mod tcp;
+
+/// Interface trait to be implemented by all external interfaces
+pub trait Interface {
+    /// Send byte data to the interface as a shared slice type byte. Return number of bytes sent
+    fn send(&mut self, data: &[u8]) -> Result<usize, Error>;
+    /// Read byte data from the interface into a byte slice buffer. Return number of bytes read
+    fn read(&mut self, buffer: &mut [u8]) -> Result<usize, Error>;
+}

--- a/ex3_shared_libs/interface/src/tcp.rs
+++ b/ex3_shared_libs/interface/src/tcp.rs
@@ -2,6 +2,7 @@
 Written by Devin Headrick and Rowan Rasmusson
 Summer 2024
 */
+use super::Interface;
 use nix::libc;
 use std::io;
 use std::io::{Error, Read, Write};
@@ -10,14 +11,6 @@ use std::os::unix::io::AsRawFd;
 
 pub const BUFFER_SIZE: usize = 1024;
 const CLIENT_POLL_TIMEOUT_MS: i32 = 100;
-
-/// Interface trait to be implemented by all external interfaces
-pub trait Interface {
-    /// Send byte data to the interface as a shared slice type byte. Return number of bytes sent
-    fn send(&mut self, data: &[u8]) -> Result<usize, Error>;
-    /// Read byte data from the interface into a byte slice buffer. Return number of bytes read
-    fn read(&mut self, buffer: &mut [u8]) -> Result<usize, Error>;
-}
 
 /// TCP Interface for communication with simulated external peripherals
 #[allow(dead_code)]

--- a/ex3_shared_libs/interface/src/uart.rs
+++ b/ex3_shared_libs/interface/src/uart.rs
@@ -1,12 +1,8 @@
-use common::message_structure::{deserialize_msg, serialize_msg, Msg};
+use super::Interface;
 use serialport::{ClearBuffer, SerialPort, SerialPortBuilder};
-use std::io::{Error as IoError, Read, Write};
+use std::io::Error;
 
 // Interface to send and read Msg structures
-pub trait Interface {
-    fn read_msg(&mut self) -> Result<Msg, IoError>;
-    fn write_msg(&mut self, msg: &Msg) -> Result<usize, IoError>;
-}
 
 // Uart interface struct.
 pub struct UARTInterface {
@@ -14,17 +10,18 @@ pub struct UARTInterface {
 }
 
 impl Interface for UARTInterface {
-    // reads a Msg structure from interface, returns a Msg struct.
-    fn read_msg(&mut self) -> Result<Msg, IoError> {
-        let mut bytes = Vec::new();
-        self.read(&mut bytes)?;
-        deserialize_msg(&bytes)
+    // reads raw bytes from uart interface into buffer, returns the number of bytes read.
+    // Note that if the number of available bytes in the buffer is less than the size of the
+    // buffer, then the remaining portion of the buffer is unmodified.
+    fn read(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
+        let result = self.interface.read(buffer);
+        self.clear_input_buffer()?;
+        result
     }
 
-    // sends a Msg structure to interface, returns the bytes written.
-    fn write_msg(&mut self, msg: &Msg) -> Result<usize, IoError> {
-        let bytes = serialize_msg(msg)?;
-        self.write(&bytes)
+    // sends raw bytes in buffer to uart interface, returns the number of bytes written.
+    fn send(&mut self, buffer: &[u8]) -> Result<usize, Error> {
+        self.interface.write(buffer)
     }
 }
 
@@ -38,7 +35,7 @@ impl UARTInterface {
     // parity: Parity::None
     // stop bits: StopBits::One
     // timeout: Duration::from_millis(0)
-    pub fn new(device_name: &str, baud_rate: u32) -> Result<UARTInterface, IoError> {
+    pub fn new(device_name: &str, baud_rate: u32) -> Result<UARTInterface, Error> {
         let port_with_settings = serialport::new(device_name, baud_rate);
         let interface = port_with_settings.open()?;
         let uart_interface = UARTInterface { interface };
@@ -51,23 +48,9 @@ impl UARTInterface {
     // parameters.
     pub fn new_with_settings(
         port_with_settings: SerialPortBuilder,
-    ) -> Result<UARTInterface, IoError> {
+    ) -> Result<UARTInterface, Error> {
         let interface = port_with_settings.open()?;
         Ok(UARTInterface { interface })
-    }
-
-    // reads raw bytes from uart interface into buffer, returns the number of bytes read.
-    // Note that if the number of available bytes in the buffer is less than the size of the
-    // buffer, then the remaining portion of the buffer is unmodified.
-    pub fn read(&mut self, buffer: &mut [u8]) -> Result<usize, IoError> {
-        let result = self.interface.read(buffer);
-        self.clear_input_buffer()?;
-        result
-    }
-
-    // sends raw bytes in buffer to uart interface, returns the number of bytes written.
-    pub fn write(&mut self, buffer: &[u8]) -> Result<usize, IoError> {
-        self.interface.write(buffer)
     }
 
     // getter for device name
@@ -82,26 +65,26 @@ impl UARTInterface {
 
     // Checks the outgoing buffer for the amount of bytes to write, returns the number of bytes in
     // the output buffer.
-    pub fn available_to_write(&mut self) -> Result<u32, IoError> {
+    pub fn available_to_write(&mut self) -> Result<u32, Error> {
         let bytes_to_write = self.interface.bytes_to_write()?;
         Ok(bytes_to_write)
     }
 
     // Checks the input buffer for the amount of bytes to read, returns the number of bytes in the
     // buffer
-    pub fn available_to_read(&mut self) -> Result<u32, IoError> {
+    pub fn available_to_read(&mut self) -> Result<u32, Error> {
         let bytes_to_read = self.interface.bytes_to_read()?;
         Ok(bytes_to_read)
     }
 
     // Clears the input buffer
-    pub fn clear_input_buffer(&self) -> Result<(), IoError> {
+    pub fn clear_input_buffer(&self) -> Result<(), Error> {
         self.interface.clear(ClearBuffer::Input)?;
         Ok(())
     }
 
     // Clears the output buffer
-    pub fn clear_output_buffer(&self) -> Result<(), IoError> {
+    pub fn clear_output_buffer(&self) -> Result<(), Error> {
         self.interface.clear(ClearBuffer::Output)?;
         Ok(())
     }


### PR DESCRIPTION
This PR is in regards to #61 and is a new version of branch #68 that includes @rcunrau changes in #69 

In this PR I defined a single Interface trait for all relevent interfaces to implement in interface/lib.rs, before this trait was defined in each interface crate in different ways (confusing). IPC does not implement this trait as its quite different then other hardware and tcp interfaces we have. I also moved the common/tcp_interface.rs to interface/tcp.rs, and with this all the changes to README's, and Cargo.toml's for the workspace to compile.