### PR TITLE
Create SPI HW Interface

### DIFF
--- a/ex3_shared_libs/README.md
+++ b/ex3_shared_libs/README.md
@@ -12,5 +12,6 @@ interface: library of I/O interface helpers that is shared among the handlers
    on the OBC. Some of the modules are:
    - ipc: inter-payload communication client/server support
    - i2c: I2C communication support
+   - spi: SPI communication support
    - uart: serial port support
    - tcp: client and server tcp support

--- a/ex3_shared_libs/interface/Cargo.toml
+++ b/ex3_shared_libs/interface/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 [dependencies]
 nix = { version = "0.29.0", features = ["socket", "fs"] }
 i2cdev = "0.6.1"
+spidev = "0.6.0"
 serialport = "4.6.0"
 common = {path = "../common"}
+

--- a/ex3_shared_libs/interface/README.md
+++ b/ex3_shared_libs/interface/README.md
@@ -8,6 +8,9 @@ This module allows userspace programs to talk with devices via a serial port con
 ## I2C Interface
 This library allows userspace programs to communicate with devices via the I2C communication protocol. It includes an I2cDeviceInterface Structure that allows the user to read and write raw bytes over the I2C interface.
 
+## I2C Interface
+This library allows userspace programs to communicate with devices via the SPI communication protocol. It includes an SpiInterface Structure that allows the user to read and write raw bytes over the SPI interface.
+
 ## IPC
 
 This is the libary used by various OBC FSW component to communicate with eachother using IPC Unix Domain Sockets of type SOCKSEQ packet.

--- a/ex3_shared_libs/interface/src/lib.rs
+++ b/ex3_shared_libs/interface/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ipc;
 pub mod i2c;
 pub mod uart;
 pub mod tcp;
+pub mod spi;
 
 /// Interface trait to be implemented by all external interfaces
 pub trait Interface {

--- a/ex3_shared_libs/interface/src/spi.rs
+++ b/ex3_shared_libs/interface/src/spi.rs
@@ -44,7 +44,10 @@ impl SpiInterface {
         spi_device.configure(&spi_config)?;
         Ok(SpiInterface {device: spi_device, path: path.to_string()})
     }
-    
+    // getter for device path
+    pub fn get_dev_path(&mut self) -> String {
+        self.path.clone()
+    }
     // Flushes the output stream
     pub fn flush_out_buff(&mut self) -> Result<(), Error> {
         self.device.flush()

--- a/ex3_shared_libs/interface/src/spi.rs
+++ b/ex3_shared_libs/interface/src/spi.rs
@@ -1,0 +1,52 @@
+use super::Interface;
+use spidev::*;
+use std::io::{Read, Write, Error};
+
+pub struct SpiInterface {
+    device: Spidev,
+    path: String,
+}
+
+impl Interface for SpiInterface {
+    // Sends the bytes from the user provided buffer to the spi device, returns the number of bytes
+    // written
+    fn send(&mut self, buff: &[u8]) -> Result<usize, Error> {
+        let bytes_written = self.device.write(buff)?;
+        Ok(bytes_written)
+    }
+
+    // Reads bytes from the spi into the buffer provided by the user, returns the number of
+    // bytes read
+    fn read(&mut self, buff: &mut [u8]) -> Result<usize, Error> {
+        let bytes_read = self.device.read(buff)?;
+        Ok(bytes_read)
+    }
+}
+
+impl SpiInterface {
+    // Function to create SpiInterface
+    pub fn new(path: &str, options: Option<SpidevOptions>) -> Result<Self, Error> {
+        let mut spi_device = Spidev::open(path)?;
+        let spi_config = match options {
+            // If user provides a SpidevOptions struct to configure spi then we create device with
+            // config
+            Some(config) => config,
+            // User did not select any config so we use the following default options
+            None => {
+                SpidevOptions::new()
+                    .bits_per_word(8)
+                    .max_speed_hz(5000)
+                    .lsb_first(false)
+                    .mode(SpiModeFlags::SPI_MODE_0)
+                    .build()
+            }
+        };
+        spi_device.configure(&spi_config)?;
+        Ok(SpiInterface {device: spi_device, path: path.to_string()})
+    }
+    
+    // Flushes the output stream
+    pub fn flush_out_buff(&mut self) -> Result<(), Error> {
+        self.device.flush()
+    }
+}


### PR DESCRIPTION
# Description
#75 
In this PR I created a thin wrapper around the Spidev structure in crate spidev to conform to our Interafce trait. The constructor for the wrapper allows the user to specify a configuration for the device they wish to communicate with, if no config is specified a default config is used.

## Feedback
@rcunrau  In the constructor for the device I return a result, should I even bother? I feel like if a program cannot create the interface we may just want the program to panic. Let me know if this is a scenario where returning a result is not useful.

I am open to any other feedback reviewers have.
