### PR TITLE
[WIP] Convert SEQ_PACKET to DGRAM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "ex3_obc_fsw/handlers/adcs_handler",
     "ex3_obc_fsw/handlers/coms_handler",
     "ex3_obc_fsw/handlers/dfgm_handler",
+    "ex3_obc_fsw/handlers/eps_handler",
     "ex3_obc_fsw/handlers/gps_handler",
     "ex3_obc_fsw/handlers/iris_handler",
     "ex3_obc_fsw/handlers/shell_handler",

--- a/ex3_ground_station/cli_ground_station/src/eps.rs
+++ b/ex3_ground_station/cli_ground_station/src/eps.rs
@@ -1,16 +1,16 @@
 use common::message_structure::Msg;
 
-pub fn parse_cmd(input: &[&str]) -> Option<Vec<u8>> {
-    match input.len() {
-        0 => {
-            println!("Missing EPS command");
-            None
-        },
-        _ => {
-            Some(input.join(" ").as_bytes().to_vec())
-        }
-    }
-}
+// pub fn parse_cmd(input: &[&str]) -> Option<Vec<u8>> {
+//     match input.len() {
+//         0 => {
+//             println!("Missing EPS command");
+//             None
+//         },
+//         _ => {
+//             Some(input.join(" ").as_bytes().to_vec())
+//         }
+//     }
+// }
 
 pub fn handle_response(msg: &Msg) {
     println!("msg: {:?}", msg);

--- a/ex3_ground_station/cli_ground_station/src/main.rs
+++ b/ex3_ground_station/cli_ground_station/src/main.rs
@@ -109,7 +109,7 @@ fn build_msg_from_operator_input(operator_str: String) -> Option<Msg> {
 
     let msg_body = match payload {
         ComponentIds::BulkMsgDispatcher => bulk::parse_cmd(&input_tokens[1..]),
-        ComponentIds::EPS => eps::parse_cmd(&input_tokens[1..]),
+//             ComponentIds::EPS => eps::parse_cmd(&input_tokens[1..]), Why?
         ComponentIds::SHELL => shell::parse_cmd(&input_tokens[1..]),
         _ => {
             opcode = input_tokens[1].parse::<u8>().unwrap();

--- a/ex3_obc_fsw/bulk_msg_dispatcher/src/main.rs
+++ b/ex3_obc_fsw/bulk_msg_dispatcher/src/main.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::{fs, io};
 use logging::*;
 use log::{trace, warn};
+use interface::Interface;
 
 const INTERNAL_MSG_BODY_SIZE: usize = 4088; // 4KB - 8 (header) being passed internally
 fn main() -> Result<(), IoError> {

--- a/ex3_obc_fsw/bulk_msg_dispatcher/src/main.rs
+++ b/ex3_obc_fsw/bulk_msg_dispatcher/src/main.rs
@@ -5,7 +5,6 @@ use message_structure::*;
 use std::fs::{File, OpenOptions};
 use std::io::Error as IoError;
 use std::io::Read;
-use std::os::fd::OwnedFd;
 use std::thread;
 use std::time::Duration;
 use std::path::Path;
@@ -46,24 +45,34 @@ fn main() -> Result<(), IoError> {
     loop {
         let mut servers = vec![&mut coms_interface, &mut cmd_disp_interface];
         thread::sleep(Duration::from_secs(1));
-        poll_ipc_server_sockets(&mut servers);
-    
+        let _ = poll_ipc_server_sockets(&mut servers);
+
         for server in servers.into_iter().flatten() {
             if let Some(msg) = handle_client(server)? {
+                // If the server is bulk msg server and msg type is ack then send bulk msgs
+                // to coms for downlink
+                println!("bulk got msg: {:?}", msg);
                 if server.socket_path.contains("gs_bulk") {
                     if msg.header.msg_type == MsgType::Ack as u8 {
-                        // TODO: Do we need the msg body to be 0? Will this disp see any other types of ACKs?
+                        trace!("Got ACK from COMS handler, starting downlink sequence.");
+                        // If the first byte of message body is 0, then then continue with downlink
+                        // process, by sending messages to gs
+                        println!("Length of message vector: {}", messages.len());
                         if msg.msg_body[0] == 0 {
                             for (i, message) in messages.iter().enumerate() {
                                 let serialized_msg = serialize_msg(message)?;
                                 trace!("Sending {} B", serialized_msg.len());
-                                if let Some(data_fd) = &server.data_fd {
-                                    ipc_write(data_fd, &serialized_msg)?;
-                                } else {
-                                    warn!("No data file descriptor found in coms_interface.");
-                                    break;
+                                match &server.client_addr {
+                                    Some(_addr) => {
+                                        let _ = server.send(&serialized_msg);
+                                    }
+                                    None => {
+                                        warn!("No client found for server");
+                                        break;
+                                    }
                                 }
                                 trace!("Sent msg #{}", i + 1);
+                                // Why
                                 thread::sleep(Duration::from_micros(1));
                             }
                             messages.clear();
@@ -84,8 +93,8 @@ fn main() -> Result<(), IoError> {
                             num_of_4kb_msgs = u16::from_le_bytes([first_msg.msg_body[0], first_msg.msg_body[1]]) + 1;
                             num_bytes = bulk_msg.msg_body.len() as u64;
                             trace!("Num of 4k msgs: {}", num_of_4kb_msgs);
-    
                             server.clear_buffer();
+                            trace!("Successfully loaded data for downlinking... waiting on ACK.");
                         }
                         Err(e) => {
                             warn!("Error reading data from path: {}", e);
@@ -94,19 +103,19 @@ fn main() -> Result<(), IoError> {
                 }
             }
         }
-    // Separate block for sending data if messages are available
-    if !messages.is_empty() {
-        if let Some(ref mut gs_bulk_server) = coms_interface {
-            if let Some(data_fd) = &gs_bulk_server.data_fd {
-                send_num_msgs_and_bytes_to_gs(num_of_4kb_msgs, num_bytes, data_fd)?;
-            } else {
-                warn!("No data file descriptor found in coms_interface.");
+        // Separate block for sending data if messages are available
+        if !messages.is_empty() {
+            println!("This weird code block is running");
+            if let Some(ref mut gs_bulk_server) = coms_interface {
+                if let Some(_client_addr) = &gs_bulk_server.client_addr {
+                    send_num_msgs_and_bytes_to_gs(num_of_4kb_msgs, num_bytes, gs_bulk_server)?;
+                    println!("Sending Ack to COM, num msg: {num_of_4kb_msgs},  num bytes: {num_bytes}");
+                } else {
+                    warn!("No data file descriptor found in coms_interface.");
+                }
             }
-            gs_bulk_server.clear_buffer();
         }
     }
-    }
-    
 }
 
 fn get_path_from_bytes(path_bytes: Vec<u8>) -> Result<String, IoError> {
@@ -132,7 +141,7 @@ fn handle_client(server: &IpcServer) -> Result<Option<Msg>, IoError> {
 
 /// This is the communication protocol that will execute each time the Bulk Msg Dispatcher wants
 /// to send a Bulk Msg to the coms handler for downlinking.
-fn send_num_msgs_and_bytes_to_gs(num_msgs: u16, num_bytes: u64, fd: &OwnedFd) -> Result<(), IoError> {
+fn send_num_msgs_and_bytes_to_gs(num_msgs: u16, num_bytes: u64, iface: &mut IpcServer) -> Result<(), IoError> {
     // 1. Send Msg to coms handler indicating Bulk Msg and buffer size needed
     let mut num_msgs_bytes: Vec<u8> = num_msgs.to_le_bytes().to_vec();
     let mut num_bytes_bytes: Vec<u8> = num_bytes.to_le_bytes().to_vec();
@@ -140,7 +149,7 @@ fn send_num_msgs_and_bytes_to_gs(num_msgs: u16, num_bytes: u64, fd: &OwnedFd) ->
     let num_msg: Msg = Msg::new(MsgType::Bulk as u8, 0,
                                 ComponentIds::GS as u8, ComponentIds::DFGM as u8,
                                 2, num_msgs_bytes);
-    ipc_write(fd, &serialize_msg(&num_msg)?)?;
+    iface.send(&serialize_msg(&num_msg)?)?;
     Ok(())
 }
 

--- a/ex3_obc_fsw/cmd_dispatcher/src/main.rs
+++ b/ex3_obc_fsw/cmd_dispatcher/src/main.rs
@@ -3,7 +3,7 @@ use nix::Error;
 use strum::IntoEnumIterator;
 use std::os::fd::AsRawFd;
 
-use interface::ipc::{poll_ipc_clients, poll_ipc_server_sockets, IpcClient, IpcServer, IPC_BUFFER_SIZE};
+use interface::ipc::{poll_ipc_server_sockets, IpcClient, IpcServer, IPC_BUFFER_SIZE};
 use common::component_ids::ComponentIds;
 use common::message_structure::MsgHeader;
 

--- a/ex3_obc_fsw/cmd_dispatcher/src/main.rs
+++ b/ex3_obc_fsw/cmd_dispatcher/src/main.rs
@@ -1,14 +1,15 @@
-use nix::unistd::{write, close};
+use nix::unistd::close;
 use nix::Error;
 use strum::IntoEnumIterator;
-use std::os::fd::{AsFd, AsRawFd};
+use std::os::fd::AsRawFd;
 
-use interface::ipc::{poll_ipc_clients, IpcClient, IPC_BUFFER_SIZE};
+use interface::ipc::{poll_ipc_clients, poll_ipc_server_sockets, IpcClient, IpcServer, IPC_BUFFER_SIZE};
 use common::component_ids::ComponentIds;
 use common::message_structure::MsgHeader;
 
+
 fn main() {
-    let component_streams: Vec<Option<IpcClient>> =
+    let mut component_streams: Vec<Option<IpcClient>> =
         ComponentIds::iter().enumerate().map(|(i,c)| {
             println!("{i}");
             match IpcClient::new(format!("{c}")) {
@@ -21,7 +22,7 @@ fn main() {
                 },
             }
         }).collect();
-    
+
     for x in 0..ComponentIds::LAST as usize {
         let payload = match ComponentIds::try_from(x as u8) {
             Ok(p) => {
@@ -36,41 +37,45 @@ fn main() {
         match component_streams.get(x) {
             Some(element) => match element {
                 Some(_e) => {
-                    println!("{} connected", payload);
+                    println!("{} socket created", payload);
                 }
                 None => {
-                    println!("{} not connected!", payload);
+                    println!("{} not created!", payload);
                 }
             },
             None => println!("bad index {}", x),
         };
     }
 
-    let mut cmd_client = match IpcClient::new("cmd_dispatcher".to_string()) {
+    // I think this should be a server. as it does not initiate communication.
+    let mut cmd_server = match IpcServer::new("cmd_dispatcher".to_string()) {
         Ok(s) => Some(s),
         Err(e) => {
-            eprintln!("Server connection error: {}", e);
+            eprintln!("Couldn't create command server: {}", e);
             return; // Should fix it and retry
         }
     };
 
     loop {
-        let mut clients = vec![&mut cmd_client];
-        let (_s,_bytes) = match poll_ipc_clients(&mut clients) {
+        let mut servers = vec![&mut cmd_server];
+        // Do not care about cmd clients addr since it only recv from a single socket in coms
+        // handler.
+        let (_bytes, _addr) = match poll_ipc_server_sockets(&mut servers) {
             Ok((bytes, sock)) => (bytes,sock),
-            Err(e) => {
-                eprintln!("read error: {}", e);
-                let _ = close(cmd_client.as_ref().unwrap().fd.as_raw_fd());
+            Err(_e) => {
+                let _ = close(cmd_server.as_ref().unwrap().fd.as_raw_fd());
                 continue; // try again
             }
         };
-        if cmd_client.as_ref().unwrap().buffer != [0u8; IPC_BUFFER_SIZE] {
-            let dest = cmd_client.as_ref().unwrap().buffer[MsgHeader::DEST_INDEX];
+        if cmd_server.as_ref().unwrap().buffer != [0u8; IPC_BUFFER_SIZE] {
+            // got message, check destination id
+            let dest = cmd_server.as_ref().unwrap().buffer[MsgHeader::DEST_INDEX];
             let res = match ComponentIds::try_from(dest) {
                 Ok(payload) => {
-                    match &component_streams[dest as usize] {
+                    match &mut component_streams[dest as usize] {
                         Some(client) => {
-                            write(client.fd.as_fd(), &cmd_client.as_ref().unwrap().buffer)
+                            let _res = client.send(&cmd_server.as_ref().unwrap().buffer);
+                            Ok(())
                         },
                         None => {
                             eprintln!("No payload: {payload}!");
@@ -86,9 +91,10 @@ fn main() {
 
             if res.is_err() {
                 eprintln!("Dispatch failed: NACKing");
+                println!("{:?}", res);
                 // Should actually NACK
             }
-            cmd_client.as_mut().unwrap().clear_buffer();
+            cmd_server.as_mut().unwrap().clear_buffer();
         }
     }
 }

--- a/ex3_obc_fsw/handlers/coms_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/coms_handler/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
     // This sets the read to be completely unblocking, so it comes with quite a bit of function
     // call overhead.
     let _ = tcp_interface.as_ref().as_mut().unwrap().stream.set_read_timeout(Some(std::time::Duration::from_millis(50)));
-    let mut uhf_buf = vec![0; UHF_MAX_MESSAGE_SIZE_BYTES as usize]; //Buffer to read incoming messages from UHF
+    let mut uhf_buf = vec![0; UHF_MAX_MESSAGE_SIZE_BYTES]; //Buffer to read incoming messages from UHF
     let mut uhf_num_bytes_read = 0;
     let mut received_bulk_ack = false;
     let mut bulk_msgs_read = 0;

--- a/ex3_obc_fsw/handlers/coms_handler/src/uhf_handler.rs
+++ b/ex3_obc_fsw/handlers/coms_handler/src/uhf_handler.rs
@@ -25,7 +25,7 @@ impl UHFHandler {
         UHFHandler {
             mode: 0,
             beacon: String::from("Beacon"),
-            buffer: vec![0; UHF_MAX_MESSAGE_SIZE_BYTES as usize],
+            buffer: vec![0; UHF_MAX_MESSAGE_SIZE_BYTES],
         }
     }
     pub fn handle_msg_for_uhf(&mut self, uhf_interface: &mut TcpInterface, msg: &Msg) {

--- a/ex3_obc_fsw/handlers/dfgm_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/dfgm_handler/src/main.rs
@@ -119,7 +119,7 @@ impl DFGMHandler {
             // let msg_dispatcher_interface = self.msg_dispatcher_interface;
 
             let mut servers = vec![&mut self.msg_dispatcher_interface];
-            poll_ipc_server_sockets(&mut servers);
+            let _ = poll_ipc_server_sockets(&mut servers);
 
             // Handling the bulk message dispatcher interface
             if let Some(cmd_msg_dispatcher) = self.msg_dispatcher_interface.as_mut() {

--- a/ex3_obc_fsw/handlers/eps_handler/Cargo.toml
+++ b/ex3_obc_fsw/handlers/eps_handler/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "eps_handler"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+common = {path = "../../../ex3_shared_libs/common"}
+interface = { path = "../../../ex3_shared_libs/interface" }
+log = "0.4.22"

--- a/ex3_obc_fsw/handlers/eps_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/eps_handler/src/main.rs
@@ -64,7 +64,7 @@ impl EPSHandler {
                 &mut msg_dispatcher_interface_option,
             ];
 
-            poll_ipc_server_sockets(&mut server);
+            let _ = poll_ipc_server_sockets(&mut server);
 
             // restore the value back into `self.dispatcher_interface` after polling. May have been mutated
             self.msg_dispatcher_interface = msg_dispatcher_interface_option;

--- a/ex3_obc_fsw/handlers/gps_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/gps_handler/src/main.rs
@@ -15,7 +15,7 @@ use log::{debug, trace, warn};
 use common::logging::*;
 use std::io::Error;
 
-use interface::ipc::{IpcClient, IpcServer, IPC_BUFFER_SIZE, ipc_write, poll_ipc_clients, poll_ipc_server_sockets};
+use interface::ipc::{IpcClient, IpcServer, IPC_BUFFER_SIZE, poll_ipc_clients, poll_ipc_server_sockets};
 use common::message_structure::*;
 
 use std::{thread, time};
@@ -56,7 +56,7 @@ impl GPSHandler {
                 &mut msg_dispatcher_interface_option,
             ];
 
-            poll_ipc_server_sockets(&mut server);
+            let _ = poll_ipc_server_sockets(&mut server);
 
             // restore the value back into `self.dispatcher_interface` after polling. May have been mutated
             self.msg_dispatcher_interface = msg_dispatcher_interface_option;
@@ -92,7 +92,9 @@ fn main() {
 
     // example (TODO add gps_interface to GPSHandler object and poll in run loop)
     let mut gps_interface = IpcClient::new("gps_device".to_string()).ok();      // connect("/tmp/fifo_socket_gps_device")
-    let _ = ipc_write(&gps_interface.as_ref().unwrap().fd, "time".as_bytes());  // send("time")
+    if let Some(ref mut gps_interface) = gps_interface {
+        let _ = gps_interface.send("time".as_bytes());  // send("time")
+    }
     thread::sleep(time::Duration::from_millis(100));                            // wait (only for example)
     let _ = poll_ipc_clients(&mut vec![&mut gps_interface]);                    // recv()
     println!("Got \"{}\"", String::from_utf8(gps_interface.as_mut().unwrap().read_buffer()).unwrap());

--- a/ex3_obc_fsw/handlers/shell_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/shell_handler/src/main.rs
@@ -65,7 +65,7 @@ impl ShellHandler {
                 &mut msg_dispatcher_interface_option,
             ];
 
-            poll_ipc_server_sockets(&mut server);
+            let _ = poll_ipc_server_sockets(&mut server);
 
             // restore the value back into `self.dispatcher_interface` after polling. May have been mutated
             self.msg_dispatcher_interface = msg_dispatcher_interface_option;

--- a/ex3_obc_fsw/msg_dispatcher/msg_dispatcher.c
+++ b/ex3_obc_fsw/msg_dispatcher/msg_dispatcher.c
@@ -34,13 +34,14 @@ int main(int argc, char *argv[])
     ComponentStruct *dfgm_handler = component_factory("dfgm_handler", DFGM);
     ComponentStruct *adcs_handler = component_factory("adcs_handler", ADCS);
     ComponentStruct *coms_handler = component_factory("coms_handler", COMS);
+    ComponentStruct *eps_handler = component_factory("eps_handler", EPS);
     ComponentStruct *gps_handler = component_factory("gps_handler", GPS);
     ComponentStruct *shell_handler = component_factory("shell_handler", SHELL);
     ComponentStruct *test_handler = component_factory("test_handler", TEST);
     ComponentStruct *bulk_dispatcher = component_factory("bulk_disp", BULK_MSG_DISPATCHER);
 
     // Array of pointers to components the message dispatcher interacts with
-    ComponentStruct *components[8] = {adcs_handler, dfgm_handler, coms_handler, gps_handler, iris_handler, bulk_dispatcher, shell_handler, test_handler};
+    ComponentStruct *components[8] = {adcs_handler, dfgm_handler, coms_handler, eps_handler, gps_handler, iris_handler, bulk_dispatcher, shell_handler, test_handler};
 
     nfds_t nfds = (unsigned long int)num_components; // num of fds we are polling
     struct pollfd *pfds;                             // fd we are polling

--- a/ex3_shared_libs/common/src/lib.rs
+++ b/ex3_shared_libs/common/src/lib.rs
@@ -23,10 +23,9 @@ pub mod ports {
 
 /// For constants that are used across the entire project
 pub mod constants {
-    pub const UHF_MAX_MESSAGE_SIZE_BYTES: u8 = 128;
+    pub const UHF_MAX_MESSAGE_SIZE_BYTES: usize = 128;
 
-    // Something up with the slicing makes this number be the size that each packet ends up 128B
-    pub const DONWLINK_MSG_BODY_SIZE: usize = 121; // 128 - 5 (header) - 2 (sequence number)
+    pub const DOWNLINK_MSG_BODY_SIZE: usize = UHF_MAX_MESSAGE_SIZE_BYTES - crate::message_structure::HEADER_SIZE;
 }
 
 /// Here opcodes and their associated meaning are defined for each component
@@ -38,6 +37,13 @@ pub mod opcodes {
         SetBeacon = 4,
         GetBeacon = 5,
         Error = 6,
+    }
+    pub enum EPS {
+        On = 1,
+        Off = 2,
+        GetHK = 3,
+        Reset = 7,
+        Error = 99,
     }
     pub enum DFGM {
         ToggleDataCollection = 0,
@@ -89,6 +95,18 @@ pub mod opcodes {
                 _ => {
                     DFGM::Error // or choose a default value or handle the error in a different way
                 }
+            }
+        }
+    }
+
+    impl From<u8> for EPS {
+        fn from(value: u8) -> Self {
+            match value {
+                1 => EPS::On,
+                2 => EPS::Off,
+                3 => EPS::GetHK,
+                7 => EPS::Reset,
+                _ => EPS::Error,
             }
         }
     }

--- a/ex3_shared_libs/interface/src/ipc.rs
+++ b/ex3_shared_libs/interface/src/ipc.rs
@@ -16,7 +16,11 @@ use std::process::exit;
 use std::io::Error as IoError;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::path::Path;
-use std::{fs, io};
+use std::{fs, io, usize};
+use common::component_ids::ComponentIds;
+use super::Interface;
+
+// TODO: Implement drop trait so that IpcClients socket paths are deleted when they go out of scope
 
 const SOCKET_PATH_PREPEND: &str = "/tmp/fifo_socket_";
 const CLIENT_PARTIAL_POSTFIX: &str = "_client_";
@@ -38,20 +42,342 @@ fn create_socket() -> Result<OwnedFd, IoError> {
 pub struct IpcClient {
     pub socket_path: String,
     pub fd: OwnedFd,
-    server_addr: UnixAddr,
+    pub server_addr: Option<UnixAddr>,
     pub buffer: [u8; IPC_BUFFER_SIZE],
+}
+
+impl Interface for IpcClient {
+    /// reads data from the given server, if client_addr_op is not None then we assign this
+    /// client's unix address to the client_addr field in the IpcServer Struct.
+    /// *** This function does not read into IpcServer's buffer field ***
+    fn read(&mut self, data: &mut [u8]) -> Result<usize, IoError> {
+        let (bytes_read, server_addr_op) = socket::recvfrom::<UnixAddr>(self.fd.as_raw_fd(), data)?;
+        if server_addr_op.is_some() {
+            // In this conditional we can check if we accidentally recv data from socket that is
+            // not our server
+            self.server_addr = server_addr_op;
+        } else {
+            return Ok(0)
+        }
+        Ok(bytes_read)
+    }
+
+    /// Sends the data to the client via IpcServer's client_addr field
+    /// if client_addr is none, then we return NotFound error
+    fn send(&mut self, data: &[u8]) -> Result<usize, IoError> {
+        if self.server_addr.is_none() {
+            // Return not found error
+            return Err(io::Error::new(io::ErrorKind::NotFound, format!("No client address for server {}", self.socket_path)));
+        }
+        // Server Address should never unwrap here
+        let bytes_sent = socket::sendto(self.fd.as_raw_fd(), data, &self.server_addr.unwrap(), socket::MsgFlags::empty())?;
+        Ok(bytes_sent)
+    }
 }
 
 impl Drop for IpcClient {
     // Delete socket file after the client goes out of scope
+    // This is not working right now. needs testing.
     fn drop(&mut self) {
         fs::remove_file(self.socket_path.as_str()).unwrap();
     }
 }
 
-/// Helper function for the purpose of deleting socket files after IpcClient and IpcServer go out
-/// of scope
-/// Search the /tmp directory for all client sockets
+impl IpcClient {
+    pub fn new(server_name: String) -> Result<IpcClient, IoError> {
+        // Creates /tmp/fifo_socket_<server_name>_client_#
+        let socket_path = gen_client_socket_path(&server_name).unwrap();
+        let socket_path_c_str = CString::new(socket_path.clone()).unwrap();
+        let socket_addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err|
+            {
+                eprintln!("Failed to create UnixAddr for client: {}", err);
+                exit(1)
+            }
+        );
+
+        // Create socket and bind previously created Unix Address to socket
+        let socket_fd = create_socket()?;
+        match bind(socket_fd.as_raw_fd(), &socket_addr) {
+            Ok(()) => {
+                println!("Successfully bound client to address {}", &socket_path);
+            }
+            Err(e) => {
+                eprintln!("Failed to bind client socket to address {} : {}", &socket_path, e);
+                exit(1)
+            }
+        }
+
+        // Initialize server addr to be /tmp/fifo_socket_<server_name>
+        let server_name = format!("{}{}", SOCKET_PATH_PREPEND, server_name);
+        let server_address_c_str = CString::new(server_name.clone()).unwrap();
+        let server_addr = UnixAddr::new(server_address_c_str.as_bytes()).unwrap_or_else(
+            |err| {
+                eprintln!("Failed to create UnixAddr for server: {}", err);
+                exit(1);
+            }
+        );
+        println!("Successfully set server address to {}", server_name);
+        let mut client = IpcClient {
+            socket_path: socket_path.clone(),
+            fd: socket_fd,
+            server_addr: Some(server_addr),
+            buffer: [0u8; IPC_BUFFER_SIZE],
+        };
+        Ok(client)
+    }
+
+
+    /// Users of this lib can call this to clear the buffer - otherwise the preivous read data will remain
+    /// the IPC client has no way of knowing when the user is done with the data in its buffer, so it is the responsibility of the user to clear it
+    pub fn clear_buffer(&mut self) {
+        self.buffer = [0u8; IPC_BUFFER_SIZE];
+        println!("Buffer cleared");
+    }
+
+    /// Returns the buffer in its current state for directly reading values in real time.
+    /// **This function also clears the buffer after the read!**
+    pub fn read_buffer(&mut self) -> Vec<u8> {
+        let tmp = self.buffer.to_vec();
+        self.clear_buffer();
+        tmp
+    }
+    pub fn send(&mut self, data: &[u8]) -> Result<usize, IoError>{
+        if self.server_addr.is_none() {
+            eprintln!("No server found for client.");
+            // return no such device or address error (ENXIO)
+            return Err(io::Error::from_raw_os_error(6));
+        }
+        // Server Address should never unwrap here
+        let ret = socket::sendto(self.fd.as_raw_fd(), data, &self.server_addr.unwrap(), socket::MsgFlags::empty())?;
+        Ok(ret)
+    }
+}
+
+/// This function polls each ipc client in the provided vector of optional clients.
+/// Returns the number of bytes read and the optional address which it was sent from if successful,
+/// if it fails it returns an IO Error.
+pub fn poll_ipc_clients(clients: &mut Vec<&mut Option<IpcClient>>) -> Result<(usize, Option<UnixAddr>), std::io::Error> {
+    //Create poll fd instances for each client
+    let mut poll_fds: Vec<libc::pollfd> = Vec::new();
+    for client in &mut *clients {
+        // Poll fd for incoming data
+        if client.is_none() {
+            return Ok((0, None));
+        }
+        poll_fds.push(libc::pollfd {
+            fd: client.as_ref().unwrap().fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        });
+    }
+
+    let poll_result = unsafe {
+        libc::poll(
+            poll_fds.as_mut_ptr(),
+            poll_fds.len() as libc::nfds_t,
+            POLL_TIMEOUT_MS,
+        )
+    };
+
+    if poll_result < 0 {
+        eprintln!(
+            "Error polling for client data: {}",
+            io::Error::last_os_error()
+        );
+        exit(1);
+    }
+
+    //Poll each client for incoming data
+    for poll_fd in poll_fds.iter() {
+        if poll_fd.revents & libc::POLLIN != 0 {
+            let client = clients.iter_mut().find(|s| s.as_ref().unwrap().fd.as_raw_fd() == poll_fd.fd);
+            if let Some(client) = client {
+                // Handle incoming data from a client
+                let (bytes_read, recv_addr) = socket::recvfrom::<UnixAddr> (client.as_ref().unwrap().fd.as_raw_fd(), &mut client.as_mut().unwrap().buffer)?;
+                if bytes_read > 0 {
+                    println!(
+                        "Received {} bytes on socket {} from {:?}",
+                        bytes_read, client.as_ref().unwrap().socket_path, &recv_addr.unwrap().path().unwrap().to_str()
+                    );
+                    return Ok((bytes_read, recv_addr));
+                }
+            }
+        }
+    }
+    Ok((0, None))
+}
+
+pub struct IpcServer {
+    pub socket_path: String,
+    pub fd: OwnedFd,
+    // client addr is the unix addr of the client most recently talked to by the server
+    pub client_addr: Option<UnixAddr>,
+    pub buffer: [u8; IPC_BUFFER_SIZE],
+}
+
+impl Interface for IpcServer {
+    /// reads data from the given server, if client_addr_op is not None then we assign this
+    /// client's unix address to the client_addr field in the IpcServer Struct.
+    /// *** This function does not read into IpcServer's buffer field ***
+    fn read(&mut self, data: &mut [u8]) -> Result<usize, IoError> {
+        let (bytes_read, client_addr_op) = socket::recvfrom::<UnixAddr>(self.fd.as_raw_fd(), data)?;
+        if client_addr_op.is_some() {
+            self.client_addr = client_addr_op;
+        } else {
+            return Ok(0)
+        }
+        Ok(bytes_read)
+    }
+
+    /// Sends the data to the client via IpcServer's client_addr field
+    /// if client_addr is none, then we return NotFound error
+    fn send(&mut self, data: &[u8]) -> Result<usize, IoError> {
+        if self.client_addr.is_none() {
+            // Return not found error
+            return Err(io::Error::new(io::ErrorKind::NotFound, format!("No client address for server {}", self.socket_path)));
+        }
+        // Server Address should never unwrap here
+        let bytes_sent = socket::sendto(self.fd.as_raw_fd(), data, &self.client_addr.unwrap(), socket::MsgFlags::empty())?;
+        Ok(bytes_sent)
+    }
+}
+
+impl IpcServer {
+    pub fn new(socket_name: String) -> Result<IpcServer, IoError> {
+        let socket_path = format!("{}{}", SOCKET_PATH_PREPEND, socket_name);
+        // This is a measure for when servers need to initiate communication with the client
+        // socket, this should not really happen. If needed we can manually set the unix address
+        // in the server struct.
+        let client_path = format!("{}{}{}", socket_path, CLIENT_PARTIAL_POSTFIX, 1);
+        let client_path_c_str = CString::new(client_path).unwrap();
+        let client_unix_addr = UnixAddr::new(client_path_c_str.as_bytes()).unwrap();
+        let socket_conn_fd = create_socket()?;
+        let mut server = IpcServer {
+            socket_path,
+            fd: socket_conn_fd,
+            // Client socket is none to start
+            client_addr: Some(client_unix_addr),
+            buffer: [0u8; IPC_BUFFER_SIZE],
+        };
+        server.bind_socket()?;
+        // Normally a server would accept conn here - but instead we do this in the polling loop
+        Ok(server)
+    }
+
+    fn bind_socket(&mut self) -> Result<(), IoError> {
+        // Create Unix Address using the string provided by user.
+        let socket_path_c_str = CString::new(self.socket_path.clone()).unwrap();
+        let addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err| {
+            eprintln!("Failed to create UnixAddr: {}", err);
+            exit(1)
+        });
+        // If the path exists already then we remove it (Otherwise we get that the socket is in use
+        // on the bind call)
+        let path = Path::new(socket_path_c_str.to_str().unwrap());
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
+
+        bind(self.fd.as_raw_fd(), &addr).unwrap_or_else(|err| {
+            eprintln!("Failed to bind socket to path: {}", err);
+            exit(1)
+        });
+
+        println!("Server socket bound to: {}", self.socket_path);
+        Ok(())
+    }
+
+    /// Users of this lib can call this to clear the buffer - otherwise the preivous read data will remain
+    ///  the IPC server has no way of knowing when the user is done with the data in its buffer, so it is the responsibility of the user to clear it
+    pub fn clear_buffer(&mut self) {
+        self.buffer = [0u8; IPC_BUFFER_SIZE];
+        println!("Buffer cleared");
+    }
+
+    /// Returns the buffer in its current state for directly reading values in real time.
+    /// **This function also clears the buffer after the read!**
+    pub fn read_buffer(&mut self) -> Vec<u8> {
+        let tmp = self.buffer.to_vec();
+        self.clear_buffer();
+        tmp
+    }
+}
+
+
+/// Takes a vector of mutable referenced IpcServers and polls them for incoming data
+/// The IpcServers must be mutable because the connected state and data_fd are mutated in the polling loop
+///
+/// This function no longer needs to poll for connections. Only input.
+pub fn poll_ipc_server_sockets(servers: &mut Vec<&mut Option<IpcServer>>) -> Result<(usize, Option<UnixAddr>), IoError> {
+    //Create poll fd instances for each client
+    let mut poll_fds: Vec<libc::pollfd> = Vec::new();
+    for server in &mut *servers {
+        // Poll fd for incoming data
+        if server.is_none() {
+            return Ok((0, None));
+        }
+        poll_fds.push(libc::pollfd {
+            fd: server.as_ref().unwrap().fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        });
+    }
+
+    let poll_result = unsafe {
+        libc::poll(
+            poll_fds.as_mut_ptr(),
+            poll_fds.len() as libc::nfds_t,
+            POLL_TIMEOUT_MS,
+        )
+    };
+
+    if poll_result < 0 {
+        eprintln!(
+            "Error polling for client data: {}",
+            io::Error::last_os_error()
+        );
+        exit(1);
+    }
+
+    //Poll each client for incoming data
+    for poll_fd in poll_fds.iter() {
+        if poll_fd.revents & libc::POLLIN != 0 {
+            let mut server = servers.iter_mut().find(|s| s.as_ref().unwrap().fd.as_raw_fd() == poll_fd.fd);
+            if let Some(ref mut server) = server {
+                // Handle incoming data from a client
+                let (bytes_read, recv_addr) = socket::recvfrom::<UnixAddr>(server.as_ref().unwrap().fd.as_raw_fd(), &mut server.as_mut().unwrap().buffer)?;
+                if bytes_read > 0 {
+                    println!(
+                        "Received {} bytes on socket {} from {:?}",
+                        bytes_read, server.as_ref().unwrap().socket_path, &recv_addr
+                    );
+                    // Set the servers client address so we know which client to respond to.
+                    server.as_mut().unwrap().client_addr = recv_addr;
+                    return Ok((bytes_read, recv_addr));
+                }
+            }
+        }
+    }
+    Ok((0, None))
+}
+
+/// Wrapper for the unistd lib write fxn
+/// Deprecated
+pub fn ipc_write(fd: &OwnedFd, data: &[u8]) -> Result<usize, std::io::Error> {
+    match write(
+        fd.as_fd(),
+        data,
+    ) {
+        Ok(bytes_read) => Ok(bytes_read),
+        Err(e) => {
+            eprintln!("Error writing to socket: {}", e);
+            Err(e.into())
+        }
+    }
+}
+
+/// Function to generate unique client address, currently the maximum number of
+/// clients per server is bottlenecked to 255 (unique identifier is u8)
 fn gen_client_socket_path(server_name: &String) -> Result<String, IoError> {
     let paths = fs::read_dir("/tmp/")?;
     let mut max: u8 = 1;
@@ -92,239 +418,59 @@ fn gen_client_socket_path(server_name: &String) -> Result<String, IoError> {
 }
 
 
-impl IpcClient {
-    pub fn new(server_name: String) -> Result<IpcClient, IoError> {
-        // creates /tmp/fifo_socket_<server_name>
-        let socket_path = format!("{}{}", SOCKET_PATH_PREPEND, server_name);
-        // creates /tmp/fifo_socket_<server_name>_client_#
-        // where # is 1-9, this means as of now we can only have 9 sockets speaking to any one
-        // server. This is absolute shit
-        let socket_path = gen_client_socket_path(&socket_path).unwrap();
-        let socket_path_c_str = CString::new(socket_path.clone()).unwrap();
-        let socket_addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err|
-            {
-                eprintln!("Failed to create UnixAddr: {}", err);
-                exit(1)
-
-            }
-        );
-
-        let socket_fd = create_socket()?;
-        match bind(socket_fd.as_raw_fd(), &socket_addr) {
-            Ok(()) => {
-                println!("Successfully bound client to address {}", &socket_path);
-            }
-            Err(e) => {
-                println!("Failed to bind client socket to address {}", &socket_path);
-                exit(1)
-            }
-
-        }
-        let mut client = IpcClient {
-            socket_path: socket_path.clone(),
-            fd: socket_fd,
-            buffer: [0u8; IPC_BUFFER_SIZE],
-        };
-        Ok(client)
-    }
-
-
-    /// Users of this lib can call this to clear the buffer - otherwise the preivous read data will remain
-    /// the IPC client has no way of knowing when the user is done with the data in its buffer, so it is the responsibility of the user to clear it
-    pub fn clear_buffer(&mut self) {
-        self.buffer = [0u8; IPC_BUFFER_SIZE];
-        println!("Buffer cleared");
-    }
-
-    /// Returns the buffer in its current state for directly reading values in real time.
-    /// **This function also clears the buffer after the read!**
-    pub fn read_buffer(&mut self) -> Vec<u8> {
-        let tmp = self.buffer.to_vec();
-        self.clear_buffer();
-        tmp
-    }
-}
-
-pub fn poll_ipc_clients(clients: &mut Vec<&mut Option<IpcClient>>) -> Result<(usize, String), std::io::Error> {
-    //Create poll fd instances for each client
-    let mut poll_fds: Vec<libc::pollfd> = Vec::new();
-    for client in &mut *clients {
-        // Poll data_fd for incoming data
-        if client.is_none() {
-            return Ok((0,"".to_string()));
-        }
-        poll_fds.push(libc::pollfd {
-            fd: client.as_ref().unwrap().fd.as_raw_fd(),
-            events: libc::POLLIN,
-            revents: 0,
-        });
-    }
-
-    let poll_result = unsafe {
-        libc::poll(
-            poll_fds.as_mut_ptr(),
-            poll_fds.len() as libc::nfds_t,
-            POLL_TIMEOUT_MS,
-        )
-    };
-
-    if poll_result < 0 {
-        eprintln!(
-            "Error polling for client data: {}",
-            io::Error::last_os_error()
-        );
-        exit(1);
-    }
-    Ok((0,"".to_string()))
-}
-
-pub struct IpcServer {
-    pub socket_path: String,
-    pub fd: OwnedFd,
-    client_addr: Option<UnixAddr>,
-    pub buffer: [u8; IPC_BUFFER_SIZE],
-}
-
-impl IpcServer {
-    pub fn new(socket_name: String) -> Result<IpcServer, IoError> {
-        let socket_path = format!("{}{}", SOCKET_PATH_PREPEND, socket_name);
-        let socket_conn_fd = create_socket()?;
-        let mut server = IpcServer {
-            socket_path,
-            fd: socket_conn_fd,
-            client_addr: None,
-            // data fd is none to start because nothing is connected
-            buffer: [0u8; IPC_BUFFER_SIZE],
-        };
-        server.bind_socket()?;
-        // Normally a server would accept conn here - but instead we do this in the polling loop
-        Ok(server)
-    }
-
-    fn bind_socket(&mut self) -> Result<(), IoError> {
-        // Create Unix Address using the string provided by user.
-        let socket_path_c_str = CString::new(self.socket_path.clone()).unwrap();
-        let addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err| {
-            eprintln!("Failed to create UnixAddr: {}", err);
-            exit(1)
-        });
-        // If the path exists already then we remove it (Otherwise we get that the socket is in use
-        // on the bind call)
-        let path = Path::new(socket_path_c_str.to_str().unwrap());
-        if path.exists() {
-            fs::remove_file(path)?;
-        }
-
-        bind(self.conn_fd.as_raw_fd(), &addr).unwrap_or_else(|err| {
-            eprintln!("Failed to bind socket to path: {}", err);
-            exit(1)
-        });
-
-        println!("Server socket bound to: {}", self.socket_path);
-
-        Ok(())
-    }
-
-    /// Users of this lib can call this to clear the buffer - otherwise the preivous read data will remain
-    ///  the IPC server has no way of knowing when the user is done with the data in its buffer, so it is the responsibility of the user to clear it
-    pub fn clear_buffer(&mut self) {
-        self.buffer = [0u8; IPC_BUFFER_SIZE];
-        println!("Buffer cleared");
-    }
-
-    /// Returns the buffer in its current state for directly reading values in real time.
-    /// **This function also clears the buffer after the read!**
-    pub fn read_buffer(&mut self) -> Vec<u8> {
-        let tmp = self.buffer.to_vec();
-        self.clear_buffer();
-        tmp
-    }
-}
-
-
-/// Takes a vector of mutable referenced IpcServers and polls them for incoming data
-/// The IpcServers must be mutable because the connected state and data_fd are mutated in the polling loop
-///
-/// This function no longer needs to poll for connections. Only input.
-pub fn poll_ipc_server_sockets(servers: &mut [&mut Option<IpcServer>]) {
-    let mut poll_fds: Vec<libc::pollfd> = Vec::new();
-
-    // Add poll descriptors based on the server's connection state
-    for server in servers.iter_mut() {
-        // Handle case where server is None
-        if server.is_none() {
-            return;
-        } else if !server.as_ref().unwrap().connected {
-            // Poll conn_fd for incoming connections
-            poll_fds.push(libc::pollfd {
-                fd: server.as_ref().unwrap().conn_fd.as_raw_fd(),
-                events: libc::POLLIN,
-                revents: 0,
-            });
-        } else if let Some(ref data_fd) = server.as_ref().unwrap().data_fd {
-            // Poll data_fd for incoming data
-            poll_fds.push(libc::pollfd {
-                fd: data_fd.as_raw_fd(),
-                events: libc::POLLIN,
-                revents: 0,
-            });
-        }
-    }
-
-    let poll_result = unsafe {
-        libc::poll(
-            poll_fds.as_mut_ptr(),
-            poll_fds.len() as libc::nfds_t,
-            POLL_TIMEOUT_MS,
-        )
-    };
-
-    if poll_result < 0 {
-        eprintln!(
-            "Error polling for client data: {}",
-            io::Error::last_os_error()
-        );
-        exit(1);
-    }
-
-    for poll_fd in poll_fds.iter() {
-        if poll_fd.revents & libc::POLLIN != 0 {
-            let server = servers
-                .iter_mut()
-                .find(|s| s.as_ref().unwrap().conn_fd.as_raw_fd() == poll_fd.fd ||
-                s.as_ref().unwrap().data_fd
-                .as_ref().unwrap().as_raw_fd() == poll_fd.fd);
-            if let Some(server) = server {
-                if !server.as_ref().unwrap().connected {
-                    // Handle new connection request from a currently unconnected client
-                    server.as_mut().unwrap().accept_connection().unwrap();
-                } else if let Some(data_fd) = &server.as_ref().unwrap().data_fd {
-                    // Handle incoming data from a connected client
-                    let bytes_read = read(data_fd.as_raw_fd(), &mut server.as_mut().unwrap().buffer).unwrap();
-                    if bytes_read == 0 {
-                        // If 0 bytes read, then the client has disconnected
-                        server.as_mut().unwrap().client_disconnected();
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Wrapper for the unistd lib write fxn
-pub fn ipc_write(fd: &OwnedFd, data: &[u8]) -> Result<usize, std::io::Error> {
-    match write(
-        fd.as_fd(),
-        data,
-    ) {
-        Ok(bytes_read) => Ok(bytes_read),
-        Err(e) => {
-            eprintln!("Error writing to socket: {}", e);
-            Err(e.into())
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::time::Duration;
+    use std::thread::sleep;
+    #[test]
+    fn test_gen_client_path() {
+        let _ = File::create("/tmp/fifo_socket_TEST_client_20").unwrap();
+        let socket_client_21 = gen_client_socket_path(&String::from("TEST")).unwrap();
+        // Create a string that should be the same as the path string created by
+        // gen_client_socket_path function.
+        let dummy_client_21_string = String::from("/tmp/fifo_socket_TEST_client_21");
+        assert!(socket_client_21 == dummy_client_21_string);
+        // Clean up after testing is done
+        fs::remove_file("/tmp/fifo_socket_TEST_client_20").unwrap();
+
+    }
+
+    #[test]
+    fn test_client_socket_drop() {
+        {
+            let _ = IpcClient::new("TEST".to_string());
+            // test to ensure file is created
+        }
+        assert!(!(fs::exists("/tmp/fifo_socket_TEST_client_1").unwrap()));
+    }
+
+    #[test]
+    fn test_server_switching_client_addr() {
+        let mut server = IpcServer::new("TEST".to_string()).unwrap();
+        let mut client_1 = IpcClient::new("TEST".to_string()).unwrap();
+        let mut client_2 = IpcClient::new("TEST".to_string()).unwrap();
+
+        client_1.send("dummy_data".as_bytes()).unwrap();
+        // Sleep a small amount of time for server to recv data
+        sleep(Duration::from_millis(5));
+        let mut buf = [0; 50];
+        server.read(&mut buf).unwrap();
+        // Check to see that client_addr has changed successfully to client_1's socket_path
+        println!("client_addr: {} | socket_path: {}", 
+            server.client_addr.unwrap().path().unwrap().to_str().unwrap(),
+            client_1.socket_path
+        );
+        assert_eq!(server.client_addr.unwrap().path().unwrap().to_str().unwrap(), client_1.socket_path);
+        client_2.send("dummy_data2".as_bytes()).unwrap();
+        sleep(Duration::from_millis(5));
+        server.read(&mut buf).unwrap();
+        // Check to see that client_addr has changed successfully to client_2's socket path
+        println!("client_addr: {} | socket_path: {}", 
+            server.client_addr.unwrap().path().unwrap().to_str().unwrap(),
+            client_2.socket_path
+        );
+        assert_eq!(server.client_addr.unwrap().path().unwrap().to_str().unwrap(), client_2.socket_path);
+    }
 }

--- a/ex3_shared_libs/interface/src/ipc.rs
+++ b/ex3_shared_libs/interface/src/ipc.rs
@@ -1,5 +1,5 @@
 /*
-Written by Devin Headrick and Rowan Rassmuson
+Written by Devin Headrick, Rowan Rassmuson, and Drake Boulianne
 Summer 2024
 
 */
@@ -7,20 +7,27 @@ use nix::libc;
 use nix::sys::socket::{self, accept, bind, listen, socket, Backlog, AddressFamily, SockFlag, SockType, UnixAddr};
 use nix::unistd::{read, write};
 use std::ffi::CString;
+use std::fmt::format;
+use std::fs::ReadDir;
+use std::os::unix::process;
+use std::str::from_utf8;
 use nix::errno::Errno;
+use std::process::exit;
 use std::io::Error as IoError;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::path::Path;
-use std::{fs, io, process};
+use std::{fs, io};
 
 const SOCKET_PATH_PREPEND: &str = "/tmp/fifo_socket_";
+const CLIENT_PARTIAL_POSTFIX: &str = "_client_";
+const SOCKET_DIR: &str = "/tmp";
 pub const IPC_BUFFER_SIZE: usize = 4096;
 const POLL_TIMEOUT_MS: i32 = 100;
 
-/// Create a unix domain socket with a type of SOCKSEQ packet.
+/// Create a unix domain socket with a type of SOCK_DGRAM.
 /// Because both server and client need to create a socket, this is a helper function outside of the structs
 fn create_socket() -> Result<OwnedFd, IoError> {
-    match socket(AddressFamily::Unix, SockType::SeqPacket, SockFlag::empty(), None) {
+    match socket(AddressFamily::Unix, SockType::Datagram, SockFlag::empty(), None) {
         Ok(fd) => Ok(fd), // unsafe { Ok(OwnedFd::from_raw_fd(fd)) },
         Err(e) => Err(IoError::from_raw_os_error(e as i32)),
     }
@@ -31,46 +38,96 @@ fn create_socket() -> Result<OwnedFd, IoError> {
 pub struct IpcClient {
     pub socket_path: String,
     pub fd: OwnedFd,
-    connected: bool,
+    server_addr: UnixAddr,
     pub buffer: [u8; IPC_BUFFER_SIZE],
 }
-impl IpcClient {
-    pub fn new(socket_name: String) -> Result<IpcClient, IoError> {
-        let socket_path = format!("{}{}", SOCKET_PATH_PREPEND, socket_name);
-        let socket_fd = create_socket()?;
-        let mut client = IpcClient {
-            socket_path: socket_path.clone(),
-            fd: socket_fd,
-            connected: false,
-            buffer: [0u8; IPC_BUFFER_SIZE],
-        };
-        client.connect_to_server()?; // Sends connection request to server
-        Ok(client)
-    }
 
-    fn connect_to_server(&mut self) -> Result<(), Errno> {
-        let socket_path_c_str = CString::new(self.socket_path.clone()).unwrap();
-        let addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err| {
-            eprintln!("Failed to create UnixAddr: {}", err);
-            process::exit(1)
-        });
-        println!(
-            "Attempting to connect to server socket at: {}",
-            self.socket_path
-        );
-        let fd: RawFd = self.fd.as_raw_fd();
-        match socket::connect(fd, &addr) {
-            Ok(()) => {
-                println!("Connected to server socket at: {}", self.socket_path);
-                self.connected = true;
-                Ok(())
-            }
-            Err(e) => {
-                eprintln!("Failed to connect to server socket: {}", e);
-                Err(e)
+impl Drop for IpcClient {
+    // Delete socket file after the client goes out of scope
+    fn drop(&mut self) {
+        fs::remove_file(self.socket_path.as_str()).unwrap();
+    }
+}
+
+/// Helper function for the purpose of deleting socket files after IpcClient and IpcServer go out
+/// of scope
+/// Search the /tmp directory for all client sockets
+fn gen_client_socket_path(server_name: &String) -> Result<String, IoError> {
+    let paths = fs::read_dir("/tmp/")?;
+    let mut max: u8 = 1;
+    for path in paths {
+        let curr_path = path.unwrap().path().to_str().unwrap().to_string();
+        // Check if the path is a client socket for the server we are trying to generate
+        // another unique socket for.
+        if curr_path.contains(server_name) && curr_path.contains(CLIENT_PARTIAL_POSTFIX) {
+            let parts = curr_path.as_str().split("_");
+            let parts: Vec<&str> = parts.collect();
+
+            // get the number at the end of the socket path indicating its unique id
+            // This value should never be none
+            let client_id = match parts.last().unwrap().parse::<u8>() {
+                Ok(id) => id,
+                Err(e) => {
+                    println!("Error parsing id from client socket path: {e}");
+                    continue;
+                }
+            };
+            // If the found client id is greater then the current max then
+            // change the max to the client id plus one
+            if client_id > max {
+                max = client_id + 1;
             }
         }
     }
+
+    // This formatted string gives "/tmp/fifo_socket_<server_name>_client_#"
+    // where # is the unique id for the client socket.
+    let new_socket_path = format!("{}{}{}{}",
+        SOCKET_PATH_PREPEND,
+        server_name,
+        CLIENT_PARTIAL_POSTFIX,
+        max
+    );
+    Ok(new_socket_path)
+}
+
+
+impl IpcClient {
+    pub fn new(server_name: String) -> Result<IpcClient, IoError> {
+        // creates /tmp/fifo_socket_<server_name>
+        let socket_path = format!("{}{}", SOCKET_PATH_PREPEND, server_name);
+        // creates /tmp/fifo_socket_<server_name>_client_#
+        // where # is 1-9, this means as of now we can only have 9 sockets speaking to any one
+        // server. This is absolute shit
+        let socket_path = gen_client_socket_path(&socket_path).unwrap();
+        let socket_path_c_str = CString::new(socket_path.clone()).unwrap();
+        let socket_addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err|
+            {
+                eprintln!("Failed to create UnixAddr: {}", err);
+                exit(1)
+
+            }
+        );
+
+        let socket_fd = create_socket()?;
+        match bind(socket_fd.as_raw_fd(), &socket_addr) {
+            Ok(()) => {
+                println!("Successfully bound client to address {}", &socket_path);
+            }
+            Err(e) => {
+                println!("Failed to bind client socket to address {}", &socket_path);
+                exit(1)
+            }
+
+        }
+        let mut client = IpcClient {
+            socket_path: socket_path.clone(),
+            fd: socket_fd,
+            buffer: [0u8; IPC_BUFFER_SIZE],
+        };
+        Ok(client)
+    }
+
 
     /// Users of this lib can call this to clear the buffer - otherwise the preivous read data will remain
     /// the IPC client has no way of knowing when the user is done with the data in its buffer, so it is the responsibility of the user to clear it
@@ -116,59 +173,43 @@ pub fn poll_ipc_clients(clients: &mut Vec<&mut Option<IpcClient>>) -> Result<(us
             "Error polling for client data: {}",
             io::Error::last_os_error()
         );
-        process::exit(1);
-    }
-
-    //Poll each client for incoming data
-    for poll_fd in poll_fds.iter() {
-        if poll_fd.revents & libc::POLLIN != 0 {
-            let client = clients.iter_mut().find(|s| s.as_ref().unwrap().fd.as_raw_fd() == poll_fd.fd);
-            if let Some(client) = client {
-                // Handle incoming data from a connected client
-                let bytes_read = read(client.as_ref().unwrap().fd.as_raw_fd(), &mut client.as_mut().unwrap().buffer)?;
-                if bytes_read > 0 {
-                    println!(
-                        "Received {} bytes on socket {}",
-                        bytes_read, client.as_ref().unwrap().socket_path
-                    );
-                    return Ok((bytes_read, client.as_ref().unwrap().socket_path.clone()));
-                }
-            }
-        }
+        exit(1);
     }
     Ok((0,"".to_string()))
 }
 
 pub struct IpcServer {
     pub socket_path: String,
-    pub conn_fd: OwnedFd,
-    pub data_fd: Option<OwnedFd>,
-    connected: bool,
+    pub fd: OwnedFd,
+    client_addr: Option<UnixAddr>,
     pub buffer: [u8; IPC_BUFFER_SIZE],
 }
+
 impl IpcServer {
     pub fn new(socket_name: String) -> Result<IpcServer, IoError> {
         let socket_path = format!("{}{}", SOCKET_PATH_PREPEND, socket_name);
         let socket_conn_fd = create_socket()?;
         let mut server = IpcServer {
             socket_path,
-            conn_fd: socket_conn_fd,
-            data_fd: None,
-            connected: false,
+            fd: socket_conn_fd,
+            client_addr: None,
+            // data fd is none to start because nothing is connected
             buffer: [0u8; IPC_BUFFER_SIZE],
         };
-        server.bind_and_listen()?;
+        server.bind_socket()?;
         // Normally a server would accept conn here - but instead we do this in the polling loop
         Ok(server)
     }
 
-    fn bind_and_listen(&mut self) -> Result<(), IoError> {
+    fn bind_socket(&mut self) -> Result<(), IoError> {
+        // Create Unix Address using the string provided by user.
         let socket_path_c_str = CString::new(self.socket_path.clone()).unwrap();
         let addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err| {
             eprintln!("Failed to create UnixAddr: {}", err);
-            process::exit(1)
+            exit(1)
         });
-
+        // If the path exists already then we remove it (Otherwise we get that the socket is in use
+        // on the bind call)
         let path = Path::new(socket_path_c_str.to_str().unwrap());
         if path.exists() {
             fs::remove_file(path)?;
@@ -176,35 +217,12 @@ impl IpcServer {
 
         bind(self.conn_fd.as_raw_fd(), &addr).unwrap_or_else(|err| {
             eprintln!("Failed to bind socket to path: {}", err);
-            process::exit(1)
+            exit(1)
         });
 
-        let sock = self.conn_fd.as_fd();
-        listen(&sock, Backlog::MAXCONN).unwrap_or_else(|err| {
-            eprintln!("Failed to listen to socket: {}", err);
-            process::exit(1)
-        });
-
-        println!("Listening to socket at: {}", self.socket_path);
+        println!("Server socket bound to: {}", self.socket_path);
 
         Ok(())
-    }
-
-    pub fn accept_connection(&mut self) -> Result<(), IoError> {
-        let fd = accept(self.conn_fd.as_raw_fd()).unwrap_or_else(|err| {
-            eprintln!("Failed to accept connection: {}", err);
-            process::exit(1)
-        });
-        self.data_fd = unsafe {Some(OwnedFd::from_raw_fd(fd))};
-        self.connected = true;
-        println!("Accepted connection from client socket {} on data fd {:?}", self.socket_path, self.data_fd);
-        Ok(())
-    }
-
-    fn client_disconnected(&mut self) {
-        self.connected = false;
-        self.data_fd = None;
-        println!("Client disconnected");
     }
 
     /// Users of this lib can call this to clear the buffer - otherwise the preivous read data will remain
@@ -226,6 +244,8 @@ impl IpcServer {
 
 /// Takes a vector of mutable referenced IpcServers and polls them for incoming data
 /// The IpcServers must be mutable because the connected state and data_fd are mutated in the polling loop
+///
+/// This function no longer needs to poll for connections. Only input.
 pub fn poll_ipc_server_sockets(servers: &mut [&mut Option<IpcServer>]) {
     let mut poll_fds: Vec<libc::pollfd> = Vec::new();
 
@@ -264,7 +284,7 @@ pub fn poll_ipc_server_sockets(servers: &mut [&mut Option<IpcServer>]) {
             "Error polling for client data: {}",
             io::Error::last_os_error()
         );
-        process::exit(1);
+        exit(1);
     }
 
     for poll_fd in poll_fds.iter() {

--- a/ex3_shared_libs/interface/src/ipc.rs
+++ b/ex3_shared_libs/interface/src/ipc.rs
@@ -4,27 +4,20 @@ Summer 2024
 
 */
 use nix::libc;
-use nix::sys::socket::{self, accept, bind, listen, socket, Backlog, AddressFamily, SockFlag, SockType, UnixAddr};
-use nix::unistd::{read, write};
+use nix::sys::socket::{self, bind, socket, AddressFamily, SockFlag, SockType, UnixAddr};
+use nix::unistd::write;
 use std::ffi::CString;
-use std::fmt::format;
-use std::fs::ReadDir;
-use std::os::unix::process;
-use std::str::from_utf8;
-use nix::errno::Errno;
 use std::process::exit;
 use std::io::Error as IoError;
-use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::Path;
-use std::{fs, io, usize};
-use common::component_ids::ComponentIds;
+use std::{fs, io};
 use super::Interface;
 
 // TODO: Implement drop trait so that IpcClients socket paths are deleted when they go out of scope
 
 const SOCKET_PATH_PREPEND: &str = "/tmp/fifo_socket_";
 const CLIENT_PARTIAL_POSTFIX: &str = "_client_";
-const SOCKET_DIR: &str = "/tmp";
 pub const IPC_BUFFER_SIZE: usize = 4096;
 const POLL_TIMEOUT_MS: i32 = 100;
 
@@ -117,7 +110,7 @@ impl IpcClient {
             }
         );
         println!("Successfully set server address to {}", server_name);
-        let mut client = IpcClient {
+        let client = IpcClient {
             socket_path: socket_path.clone(),
             fd: socket_fd,
             server_addr: Some(server_addr),

--- a/scripts/test_eps_handler.sh
+++ b/scripts/test_eps_handler.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 # Written by Kaaden RumanCam
-# Summer 2024
+# Fall 2024
 
 # User must provide the path to the simulated subsystem directory on their machine as the first arg
 PATH_TO_SIM_SUBS=$1
@@ -12,7 +12,10 @@ fi;
 echo "Path being used to sim subs: $PATH_TO_SIM_SUBS"
 
 # Create a detached session using our config file to hold our windows
-tmux -f .tmux.conf new-session -d -s "test_shell_handler"
+tmux -f .tmux.conf new-session -d -s "test_eps_handler"
+
+# Launch the EPS simulator
+tmux new-window -n "SIM_EPS" -- "trap : SIGINT; cd $PATH_TO_SIM_SUBS/EPS && python3 eps_subsystem.py; exec bash"
 
 # Create bulk msg dispatcher
 tmux new-window -n "BULK_MSG_DISPATCHER" -- "trap : SIGINT; cd ../ex3_obc_fsw/bulk_msg_dispatcher && cargo run; exec bash"
@@ -23,8 +26,8 @@ tmux new-window -n "SIM_UHF_SUBSYSTEM" -- "trap : SIGINT; cd $PATH_TO_SIM_SUBS/U
 tmux new-window -n "COMS_HANDLER" -- "trap : SIGINT; cd ../ && cargo run --bin coms_handler; exec bash"
 sleep 0.25
 
-## Launch the shell command handler
-tmux new-window -n "SHELL_HANDLER" -- "trap : SIGINT; cd ../ && cargo run --bin shell_handler; exec bash"
+## Launch the eps handler
+tmux new-window -n "EPS_HANDLER" -- "trap : SIGINT; cd ../ && cargo run --bin eps_handler; exec bash"
 sleep 0.25
 
 ## Create the msg dispatcher (last component of the obc fsw because it creates ipc clients
@@ -34,4 +37,4 @@ sleep 0.25
 ## Launch the GS simulation (this can just be a tcp server for now )
 tmux new-window -n "SIM_GS" -- "trap : SIGINT; cd ../ && cargo run --bin cli_ground_station; exec bash"
 
-tmux attach-session -t "test_shell_handler"
+tmux attach-session -t "test_eps_handler"

--- a/scripts/test_gps_handler.sh
+++ b/scripts/test_gps_handler.sh
@@ -21,6 +21,9 @@ tmux new-window -n "SIM_GPS" -- "trap : SIGINT; cd $PATH_TO_SIM_SUBS/GPS && pyth
 tmux new-window -n "BULK_MSG_DISPATCHER" -- "trap : SIGINT; cd ../ex3_obc_fsw/bulk_msg_dispatcher && cargo run; exec bash"
 sleep 0.25
 
+tmux new-window -n "SIM_UHF_SUBSYSTEM" -- "trap : SIGINT; cd $PATH_TO_SIM_SUBS/UHF && python3 ./simulated_uhf.py ; exec bash;"
+sleep 0.25
+
 tmux new-window -n "COMS_HANDLER" -- "trap : SIGINT; cd ../ && cargo run --bin coms_handler; exec bash"
 sleep 0.25
 


### PR DESCRIPTION
In regards to #48 

In this PR I converted our IPC library to use datagram sockets rather then sequenced packets. During this rewrite I implemented the Interface trait for IpcServer and IpcClient structs, wrote unit tests, and made minor changes to flight software files so that they were compatible after the rewrite. This is still a work in progress, things I want to implement in the future are error checking and automatic re-requesting packets that are garbled (Although this may not be included in this PR). I am also running into issues when attempting to drop the IpcClient structs below is a summary of the issue:

Due to re-write IpcClients are now bound to unix addresses (Which was not the case previously), this means on creation a socket file is created in the /tmp directory (like IpcServer). Since more then one client can talk to any given server I made a helper function for generating unique client file paths for the socket file. For cleanup I implemented the drop trait for IpcClient as to remove the socket file. During unit testing the drop trait works as intended, but when running uplink or downlink script and quitting using EOF the drop() function does not run so I am left with a bunch of socket files in the temporary directory. If we try to run either script again the components panic because these socket file paths still exist so the bind function fails. 

I am open to all feedback, specifically any recommendation on how I can solve the issue previously described with the drop function.