### PR TITLE
Converting IPC lib socket type to datagram

### DIFF
--- a/ex3_obc_fsw/cmd_dispatcher/src/main.rs
+++ b/ex3_obc_fsw/cmd_dispatcher/src/main.rs
@@ -1,14 +1,14 @@
-use nix::unistd::{write, close};
+use nix::unistd::close;
 use nix::Error;
 use strum::IntoEnumIterator;
-use std::os::fd::{AsFd, AsRawFd};
+use std::os::fd::AsRawFd;
 
-use interface::ipc::{poll_ipc_clients, IpcClient, IPC_BUFFER_SIZE};
+use interface::ipc::{poll_ipc_server_sockets, IpcClient, IpcServer, IPC_BUFFER_SIZE};
 use common::component_ids::ComponentIds;
 use common::message_structure::MsgHeader;
 
 fn main() {
-    let component_streams: Vec<Option<IpcClient>> =
+    let mut component_streams: Vec<Option<IpcClient>> =
         ComponentIds::iter().enumerate().map(|(i,c)| {
             println!("{i}");
             match IpcClient::new(format!("{c}")) {
@@ -46,7 +46,7 @@ fn main() {
         };
     }
 
-    let mut cmd_client = match IpcClient::new("cmd_dispatcher".to_string()) {
+    let mut cmd_server = match IpcServer::new("cmd_dispatcher".to_string()) {
         Ok(s) => Some(s),
         Err(e) => {
             eprintln!("Server connection error: {}", e);
@@ -55,22 +55,23 @@ fn main() {
     };
 
     loop {
-        let mut clients = vec![&mut cmd_client];
-        let (_s,_bytes) = match poll_ipc_clients(&mut clients) {
+        let mut servers = vec![&mut cmd_server];
+        let (_s,_bytes) = match poll_ipc_server_sockets(&mut servers) {
             Ok((bytes, sock)) => (bytes,sock),
             Err(e) => {
                 eprintln!("read error: {}", e);
-                let _ = close(cmd_client.as_ref().unwrap().fd.as_raw_fd());
+                let _ = close(cmd_server.as_ref().unwrap().fd.as_raw_fd());
                 continue; // try again
             }
         };
-        if cmd_client.as_ref().unwrap().buffer != [0u8; IPC_BUFFER_SIZE] {
-            let dest = cmd_client.as_ref().unwrap().buffer[MsgHeader::DEST_INDEX];
+        if cmd_server.as_ref().unwrap().buffer != [0u8; IPC_BUFFER_SIZE] {
+            let dest = cmd_server.as_ref().unwrap().buffer[MsgHeader::DEST_INDEX];
             let res = match ComponentIds::try_from(dest) {
                 Ok(payload) => {
-                    match &component_streams[dest as usize] {
+                    match &mut component_streams[dest as usize] {
                         Some(client) => {
-                            write(client.fd.as_fd(), &cmd_client.as_ref().unwrap().buffer)
+                            let _ = client.send(&cmd_server.as_ref().unwrap().buffer);
+                            Ok(())
                         },
                         None => {
                             eprintln!("No payload: {payload}!");
@@ -88,7 +89,7 @@ fn main() {
                 eprintln!("Dispatch failed: NACKing");
                 // Should actually NACK
             }
-            cmd_client.as_mut().unwrap().clear_buffer();
+            cmd_server.as_mut().unwrap().clear_buffer();
         }
     }
 }

--- a/ex3_obc_fsw/handlers/dfgm_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/dfgm_handler/src/main.rs
@@ -119,7 +119,7 @@ impl DFGMHandler {
             // let msg_dispatcher_interface = self.msg_dispatcher_interface;
 
             let mut servers = vec![&mut self.msg_dispatcher_interface];
-            poll_ipc_server_sockets(&mut servers);
+            let _ = poll_ipc_server_sockets(&mut servers);
 
             // Handling the bulk message dispatcher interface
             if let Some(cmd_msg_dispatcher) = self.msg_dispatcher_interface.as_mut() {

--- a/ex3_obc_fsw/handlers/eps_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/eps_handler/src/main.rs
@@ -64,7 +64,7 @@ impl EPSHandler {
                 &mut msg_dispatcher_interface_option,
             ];
 
-            poll_ipc_server_sockets(&mut server);
+            let _ = poll_ipc_server_sockets(&mut server);
 
             // restore the value back into `self.dispatcher_interface` after polling. May have been mutated
             self.msg_dispatcher_interface = msg_dispatcher_interface_option;
@@ -116,9 +116,9 @@ impl EPSHandler {
         resp.truncate(DOWNLINK_MSG_BODY_SIZE);
 
         let msg = Msg::new(MsgType::Cmd as u8, 0, GS as u8, EPS as u8, 0, resp.as_bytes().to_vec());
-        if let Some(gs_resp_interface) = &self.gs_interface {
-            let _ = ipc_write(&gs_resp_interface.fd, &serialize_msg(&msg)?);
-        } else {
+        if let Some(ref mut gs_resp_interface) = self.gs_interface {
+            let _ = gs_resp_interface.send(&serialize_msg(&msg)?);
+        } else  {
             debug!("Response not sent to gs. IPC interface not created");
         }
 

--- a/ex3_obc_fsw/handlers/shell_handler/src/main.rs
+++ b/ex3_obc_fsw/handlers/shell_handler/src/main.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 
 use common::component_ids::ComponentIds::{GS, SHELL};
 use common::constants::DOWNLINK_MSG_BODY_SIZE;
-use interface::ipc::{IpcClient, IpcServer, IPC_BUFFER_SIZE, ipc_write, poll_ipc_server_sockets};
+use interface::ipc::{IpcClient, IpcServer, IPC_BUFFER_SIZE, poll_ipc_server_sockets};
 use log::{debug, trace, warn};
 use common::logging::*;
 use common::message_structure::*;
@@ -65,7 +65,7 @@ impl ShellHandler {
                 &mut msg_dispatcher_interface_option,
             ];
 
-            poll_ipc_server_sockets(&mut server);
+            let _ = poll_ipc_server_sockets(&mut server);
 
             // restore the value back into `self.dispatcher_interface` after polling. May have been mutated
             self.msg_dispatcher_interface = msg_dispatcher_interface_option;
@@ -93,8 +93,8 @@ impl ShellHandler {
 
                 for chunk in out.stdout.chunks(DOWNLINK_MSG_BODY_SIZE) {
                     let msg = Msg::new(MsgType::Cmd as u8, 0, GS as u8, SHELL as u8, 0, chunk.to_vec());
-                    if let Some(gs_resp_interface) = &self.gs_interface {
-                        let _ = ipc_write(&gs_resp_interface.fd, &serialize_msg(&msg)?);
+                    if let Some(ref mut gs_resp_interface) = self.gs_interface {
+                        let _ = gs_resp_interface.send(&serialize_msg(&msg)?);
                     } else {
                         debug!("Response not sent to gs. IPC interface not created");
                     }

--- a/ex3_shared_libs/interface/src/ipc.rs
+++ b/ex3_shared_libs/interface/src/ipc.rs
@@ -1,29 +1,32 @@
 /*
-Written by Devin Headrick and Rowan Rassmuson
+Written by Devin Headrick, Rowan Rassmuson, and Drake Boulianne
 Summer 2024
 
 */
 use nix::libc;
-use nix::sys::socket::{self, accept, bind, listen, socket, Backlog, AddressFamily, SockFlag, SockType, UnixAddr};
-use nix::unistd::{read, write};
+use nix::sys::socket::{self, bind, socket, AddressFamily, SockFlag, SockType, UnixAddr};
+use nix::unistd::write;
 use std::ffi::CString;
-use nix::errno::Errno;
+use nix::unistd::unlink;
+use std::process::exit;
 use std::io::Error as IoError;
-use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::Path;
-use std::{fs, io, process};
+use std::{fs, io};
+use super::Interface;
+
+// TODO: Implement drop trait so that IpcClients socket paths are deleted when they go out of scope
 
 const SOCKET_PATH_PREPEND: &str = "/tmp/fifo_socket_";
+const CLIENT_PARTIAL_POSTFIX: &str = "_client_";
 pub const IPC_BUFFER_SIZE: usize = 4096;
 const POLL_TIMEOUT_MS: i32 = 100;
 
-/// Create a unix domain socket with a type of SOCKSEQ packet.
+/// Create a unix domain socket with a type of SOCK_DGRAM.
 /// Because both server and client need to create a socket, this is a helper function outside of the structs
 fn create_socket() -> Result<OwnedFd, IoError> {
-    match socket(AddressFamily::Unix, SockType::SeqPacket, SockFlag::empty(), None) {
-        Ok(fd) => Ok(fd), // unsafe { Ok(OwnedFd::from_raw_fd(fd)) },
-        Err(e) => Err(IoError::from_raw_os_error(e as i32)),
-    }
+    let sock_fd = socket(AddressFamily::Unix, SockType::Datagram, SockFlag::empty(), None)?;
+    Ok(sock_fd)
 }
 
 /// Client struct using a unix domain socket of type SOCKSEQ packet, that connects to a server socket
@@ -31,46 +34,95 @@ fn create_socket() -> Result<OwnedFd, IoError> {
 pub struct IpcClient {
     pub socket_path: String,
     pub fd: OwnedFd,
-    connected: bool,
+    pub server_addr: Option<UnixAddr>,
     pub buffer: [u8; IPC_BUFFER_SIZE],
 }
+
+impl Interface for IpcClient {
+    /// reads data from the given server, if client_addr_op is not None then we assign this
+    /// client's unix address to the client_addr field in the IpcServer Struct.
+    /// *** This function does not read into IpcServer's buffer field ***
+    fn read(&mut self, data: &mut [u8]) -> Result<usize, IoError> {
+        let (bytes_read, server_addr_op) = socket::recvfrom::<UnixAddr>(self.fd.as_raw_fd(), data)?;
+        if server_addr_op.is_some() {
+            // In this conditional we can check if we accidentally recv data from socket that is
+            // not our server
+            self.server_addr = server_addr_op;
+        } else {
+            return Ok(0)
+        }
+        Ok(bytes_read)
+    }
+
+    /// Sends the data to the client via IpcServer's client_addr field
+    /// if client_addr is none, then we return NotFound error
+    fn send(&mut self, data: &[u8]) -> Result<usize, IoError> {
+        if self.server_addr.is_none() {
+            // Return not found error
+            return Err(io::Error::new(io::ErrorKind::NotFound, format!("No client address for server {}", self.socket_path)));
+        }
+        // Server Address should never unwrap here
+        let bytes_sent = socket::sendto(self.fd.as_raw_fd(), data, &self.server_addr.unwrap(), socket::MsgFlags::empty())?;
+        Ok(bytes_sent)
+    }
+}
+
+impl Drop for IpcClient {
+    // Delete socket file after the client goes out of scope
+    // This is not working right now. needs testing.
+    fn drop(&mut self) {
+        fs::remove_file(self.socket_path.as_str()).unwrap();
+    }
+}
+
 impl IpcClient {
-    pub fn new(socket_name: String) -> Result<IpcClient, IoError> {
-        let socket_path = format!("{}{}", SOCKET_PATH_PREPEND, socket_name);
+    pub fn new(server_name: String) -> Result<IpcClient, IoError> {
+        // Creates /tmp/fifo_socket_<server_name>_client_#
+        let socket_path = gen_client_socket_path(&server_name).unwrap();
+        let socket_path_c_str = CString::new(socket_path.clone()).unwrap();
+        let socket_addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err|
+            {
+                eprintln!("Failed to create UnixAddr for client: {}", err);
+                exit(1)
+            }
+        );
+
+        // Create socket and bind previously created Unix Address to socket
+
         let socket_fd = create_socket()?;
-        let mut client = IpcClient {
+        // This is apparently not best practice but I am already generating a unique name to bind
+        // to so we should be okay doing this.
+        if fs::exists(socket_path.clone()).unwrap() {
+            unlink(socket_path.as_str()).unwrap();
+        }
+        match bind(socket_fd.as_raw_fd(), &socket_addr) {
+            Ok(()) => {
+                println!("Successfully bound client to address {}", &socket_path);
+            }
+            Err(e) => {
+                eprintln!("Failed to bind client socket to address {} : {}", &socket_path, e);
+                exit(1)
+            }
+        }
+        // Initialize server addr to be /tmp/fifo_socket_<server_name>
+        let server_name = format!("{}{}", SOCKET_PATH_PREPEND, server_name);
+        let server_address_c_str = CString::new(server_name.clone()).unwrap();
+        let server_addr = UnixAddr::new(server_address_c_str.as_bytes()).unwrap_or_else(
+            |err| {
+                eprintln!("Failed to create UnixAddr for server: {}", err);
+                exit(1);
+            }
+        );
+        println!("Successfully set server address to {}", server_name);
+        let client = IpcClient {
             socket_path: socket_path.clone(),
             fd: socket_fd,
-            connected: false,
+            server_addr: Some(server_addr),
             buffer: [0u8; IPC_BUFFER_SIZE],
         };
-        client.connect_to_server()?; // Sends connection request to server
         Ok(client)
     }
 
-    fn connect_to_server(&mut self) -> Result<(), Errno> {
-        let socket_path_c_str = CString::new(self.socket_path.clone()).unwrap();
-        let addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err| {
-            eprintln!("Failed to create UnixAddr: {}", err);
-            process::exit(1)
-        });
-        println!(
-            "Attempting to connect to server socket at: {}",
-            self.socket_path
-        );
-        let fd: RawFd = self.fd.as_raw_fd();
-        match socket::connect(fd, &addr) {
-            Ok(()) => {
-                println!("Connected to server socket at: {}", self.socket_path);
-                self.connected = true;
-                Ok(())
-            }
-            Err(e) => {
-                eprintln!("Failed to connect to server socket: {}", e);
-                Err(e)
-            }
-        }
-    }
 
     /// Users of this lib can call this to clear the buffer - otherwise the preivous read data will remain
     /// the IPC client has no way of knowing when the user is done with the data in its buffer, so it is the responsibility of the user to clear it
@@ -86,15 +138,28 @@ impl IpcClient {
         self.clear_buffer();
         tmp
     }
+    pub fn send(&mut self, data: &[u8]) -> Result<usize, IoError>{
+        if self.server_addr.is_none() {
+            eprintln!("No server found for client.");
+            // return no such device or address error (ENXIO)
+            return Err(io::Error::from_raw_os_error(6));
+        }
+        // Server Address should never unwrap here
+        let ret = socket::sendto(self.fd.as_raw_fd(), data, &self.server_addr.unwrap(), socket::MsgFlags::empty())?;
+        Ok(ret)
+    }
 }
 
-pub fn poll_ipc_clients(clients: &mut Vec<&mut Option<IpcClient>>) -> Result<(usize, String), std::io::Error> {
+/// This function polls each ipc client in the provided vector of optional clients.
+/// Returns the number of bytes read and the optional address which it was sent from if successful,
+/// if it fails it returns an IO Error.
+pub fn poll_ipc_clients(clients: &mut Vec<&mut Option<IpcClient>>) -> Result<(usize, Option<UnixAddr>), std::io::Error> {
     //Create poll fd instances for each client
     let mut poll_fds: Vec<libc::pollfd> = Vec::new();
     for client in &mut *clients {
-        // Poll data_fd for incoming data
+        // Poll fd for incoming data
         if client.is_none() {
-            return Ok((0,"".to_string()));
+            return Ok((0, None));
         }
         poll_fds.push(libc::pollfd {
             fd: client.as_ref().unwrap().fd.as_raw_fd(),
@@ -116,7 +181,7 @@ pub fn poll_ipc_clients(clients: &mut Vec<&mut Option<IpcClient>>) -> Result<(us
             "Error polling for client data: {}",
             io::Error::last_os_error()
         );
-        process::exit(1);
+        exit(1);
     }
 
     //Poll each client for incoming data
@@ -124,87 +189,99 @@ pub fn poll_ipc_clients(clients: &mut Vec<&mut Option<IpcClient>>) -> Result<(us
         if poll_fd.revents & libc::POLLIN != 0 {
             let client = clients.iter_mut().find(|s| s.as_ref().unwrap().fd.as_raw_fd() == poll_fd.fd);
             if let Some(client) = client {
-                // Handle incoming data from a connected client
-                let bytes_read = read(client.as_ref().unwrap().fd.as_raw_fd(), &mut client.as_mut().unwrap().buffer)?;
+                // Handle incoming data from a client
+                let (bytes_read, recv_addr) = socket::recvfrom::<UnixAddr> (client.as_ref().unwrap().fd.as_raw_fd(), &mut client.as_mut().unwrap().buffer)?;
                 if bytes_read > 0 {
                     println!(
-                        "Received {} bytes on socket {}",
-                        bytes_read, client.as_ref().unwrap().socket_path
+                        "Received {} bytes on socket {} from {:?}",
+                        bytes_read, client.as_ref().unwrap().socket_path, &recv_addr.unwrap().path().unwrap().to_str()
                     );
-                    return Ok((bytes_read, client.as_ref().unwrap().socket_path.clone()));
+                    return Ok((bytes_read, recv_addr));
                 }
             }
         }
     }
-    Ok((0,"".to_string()))
+    Ok((0, None))
 }
 
 pub struct IpcServer {
     pub socket_path: String,
-    pub conn_fd: OwnedFd,
-    pub data_fd: Option<OwnedFd>,
-    connected: bool,
+    pub fd: OwnedFd,
+    // client addr is the unix addr of the client most recently talked to by the server
+    pub client_addr: Option<UnixAddr>,
     pub buffer: [u8; IPC_BUFFER_SIZE],
 }
+
+impl Interface for IpcServer {
+    /// reads data from the given server, if client_addr_op is not None then we assign this
+    /// client's unix address to the client_addr field in the IpcServer Struct.
+    /// *** This function does not read into IpcServer's buffer field ***
+    fn read(&mut self, data: &mut [u8]) -> Result<usize, IoError> {
+        let (bytes_read, client_addr_op) = socket::recvfrom::<UnixAddr>(self.fd.as_raw_fd(), data)?;
+        if client_addr_op.is_some() {
+            self.client_addr = client_addr_op;
+        } else {
+            return Ok(0)
+        }
+        Ok(bytes_read)
+    }
+
+    /// Sends the data to the client via IpcServer's client_addr field
+    /// if client_addr is none, then we return NotFound error
+    fn send(&mut self, data: &[u8]) -> Result<usize, IoError> {
+        if self.client_addr.is_none() {
+            // Return not found error
+            return Err(io::Error::new(io::ErrorKind::NotFound, format!("No client address for server {}", self.socket_path)));
+        }
+        // Server Address should never unwrap here
+        let bytes_sent = socket::sendto(self.fd.as_raw_fd(), data, &self.client_addr.unwrap(), socket::MsgFlags::empty())?;
+        Ok(bytes_sent)
+    }
+}
+
 impl IpcServer {
     pub fn new(socket_name: String) -> Result<IpcServer, IoError> {
         let socket_path = format!("{}{}", SOCKET_PATH_PREPEND, socket_name);
+        // This is a measure for when servers need to initiate communication with the client
+        // socket, this should not really happen. If needed we can manually set the unix address
+        // in the server struct.
+        let client_path = format!("{}{}{}", socket_path, CLIENT_PARTIAL_POSTFIX, 1);
+        let client_path_c_str = CString::new(client_path).unwrap();
+        let client_unix_addr = UnixAddr::new(client_path_c_str.as_bytes()).unwrap();
         let socket_conn_fd = create_socket()?;
         let mut server = IpcServer {
             socket_path,
-            conn_fd: socket_conn_fd,
-            data_fd: None,
-            connected: false,
+            fd: socket_conn_fd,
+            // Client socket is none to start
+            client_addr: Some(client_unix_addr),
             buffer: [0u8; IPC_BUFFER_SIZE],
         };
-        server.bind_and_listen()?;
+        server.bind_socket()?;
         // Normally a server would accept conn here - but instead we do this in the polling loop
         Ok(server)
     }
 
-    fn bind_and_listen(&mut self) -> Result<(), IoError> {
+    fn bind_socket(&mut self) -> Result<(), IoError> {
+        // Create Unix Address using the string provided by user.
         let socket_path_c_str = CString::new(self.socket_path.clone()).unwrap();
         let addr = UnixAddr::new(socket_path_c_str.as_bytes()).unwrap_or_else(|err| {
             eprintln!("Failed to create UnixAddr: {}", err);
-            process::exit(1)
+            exit(1)
         });
-
+        // If the path exists already then we remove it (Otherwise we get that the socket is in use
+        // on the bind call)
         let path = Path::new(socket_path_c_str.to_str().unwrap());
         if path.exists() {
             fs::remove_file(path)?;
         }
 
-        bind(self.conn_fd.as_raw_fd(), &addr).unwrap_or_else(|err| {
+        bind(self.fd.as_raw_fd(), &addr).unwrap_or_else(|err| {
             eprintln!("Failed to bind socket to path: {}", err);
-            process::exit(1)
+            exit(1)
         });
 
-        let sock = self.conn_fd.as_fd();
-        listen(&sock, Backlog::MAXCONN).unwrap_or_else(|err| {
-            eprintln!("Failed to listen to socket: {}", err);
-            process::exit(1)
-        });
-
-        println!("Listening to socket at: {}", self.socket_path);
-
+        println!("Server socket bound to: {}", self.socket_path);
         Ok(())
-    }
-
-    pub fn accept_connection(&mut self) -> Result<(), IoError> {
-        let fd = accept(self.conn_fd.as_raw_fd()).unwrap_or_else(|err| {
-            eprintln!("Failed to accept connection: {}", err);
-            process::exit(1)
-        });
-        self.data_fd = unsafe {Some(OwnedFd::from_raw_fd(fd))};
-        self.connected = true;
-        println!("Accepted connection from client socket {} on data fd {:?}", self.socket_path, self.data_fd);
-        Ok(())
-    }
-
-    fn client_disconnected(&mut self) {
-        self.connected = false;
-        self.data_fd = None;
-        println!("Client disconnected");
     }
 
     /// Users of this lib can call this to clear the buffer - otherwise the preivous read data will remain
@@ -226,29 +303,21 @@ impl IpcServer {
 
 /// Takes a vector of mutable referenced IpcServers and polls them for incoming data
 /// The IpcServers must be mutable because the connected state and data_fd are mutated in the polling loop
-pub fn poll_ipc_server_sockets(servers: &mut [&mut Option<IpcServer>]) {
+///
+/// This function no longer needs to poll for connections. Only input.
+pub fn poll_ipc_server_sockets(servers: &mut Vec<&mut Option<IpcServer>>) -> Result<(usize, Option<UnixAddr>), IoError> {
+    //Create poll fd instances for each client
     let mut poll_fds: Vec<libc::pollfd> = Vec::new();
-
-    // Add poll descriptors based on the server's connection state
-    for server in servers.iter_mut() {
-        // Handle case where server is None
+    for server in &mut *servers {
+        // Poll fd for incoming data
         if server.is_none() {
-            return;
-        } else if !server.as_ref().unwrap().connected {
-            // Poll conn_fd for incoming connections
-            poll_fds.push(libc::pollfd {
-                fd: server.as_ref().unwrap().conn_fd.as_raw_fd(),
-                events: libc::POLLIN,
-                revents: 0,
-            });
-        } else if let Some(ref data_fd) = server.as_ref().unwrap().data_fd {
-            // Poll data_fd for incoming data
-            poll_fds.push(libc::pollfd {
-                fd: data_fd.as_raw_fd(),
-                events: libc::POLLIN,
-                revents: 0,
-            });
+            return Ok((0, None));
         }
+        poll_fds.push(libc::pollfd {
+            fd: server.as_ref().unwrap().fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        });
     }
 
     let poll_result = unsafe {
@@ -264,34 +333,34 @@ pub fn poll_ipc_server_sockets(servers: &mut [&mut Option<IpcServer>]) {
             "Error polling for client data: {}",
             io::Error::last_os_error()
         );
-        process::exit(1);
+        exit(1);
     }
 
+    //Poll each client for incoming data
     for poll_fd in poll_fds.iter() {
         if poll_fd.revents & libc::POLLIN != 0 {
-            let server = servers
-                .iter_mut()
-                .find(|s| s.as_ref().unwrap().conn_fd.as_raw_fd() == poll_fd.fd ||
-                s.as_ref().unwrap().data_fd
-                .as_ref().unwrap().as_raw_fd() == poll_fd.fd);
-            if let Some(server) = server {
-                if !server.as_ref().unwrap().connected {
-                    // Handle new connection request from a currently unconnected client
-                    server.as_mut().unwrap().accept_connection().unwrap();
-                } else if let Some(data_fd) = &server.as_ref().unwrap().data_fd {
-                    // Handle incoming data from a connected client
-                    let bytes_read = read(data_fd.as_raw_fd(), &mut server.as_mut().unwrap().buffer).unwrap();
-                    if bytes_read == 0 {
-                        // If 0 bytes read, then the client has disconnected
-                        server.as_mut().unwrap().client_disconnected();
-                    }
+            let mut server = servers.iter_mut().find(|s| s.as_ref().unwrap().fd.as_raw_fd() == poll_fd.fd);
+            if let Some(ref mut server) = server {
+                // Handle incoming data from a client
+                let (bytes_read, recv_addr) = socket::recvfrom::<UnixAddr>(server.as_ref().unwrap().fd.as_raw_fd(), &mut server.as_mut().unwrap().buffer)?;
+                if bytes_read > 0 {
+                    println!(
+                        "Received {} bytes on socket {} from {:?}",
+                        bytes_read, server.as_ref().unwrap().socket_path,
+                        &recv_addr.unwrap().path().unwrap().to_str().unwrap()
+                    );
+                    // Set the servers client address so we know which client to respond to.
+                    server.as_mut().unwrap().client_addr = recv_addr;
+                    return Ok((bytes_read, recv_addr));
                 }
             }
         }
     }
+    Ok((0, None))
 }
 
 /// Wrapper for the unistd lib write fxn
+/// Deprecated
 pub fn ipc_write(fd: &OwnedFd, data: &[u8]) -> Result<usize, std::io::Error> {
     match write(
         fd.as_fd(),
@@ -305,6 +374,102 @@ pub fn ipc_write(fd: &OwnedFd, data: &[u8]) -> Result<usize, std::io::Error> {
     }
 }
 
+/// Function to generate unique client address, currently the maximum number of
+/// clients per server is bottlenecked to 255 (unique identifier is u8)
+fn gen_client_socket_path(server_name: &String) -> Result<String, IoError> {
+    let paths = fs::read_dir("/tmp/")?;
+    let mut max: u8 = 1;
+    for path in paths {
+        let curr_path = path.unwrap().path().to_str().unwrap().to_string();
+        // Check if the path is a client socket for the server we are trying to generate
+        // another unique socket path for.
+        if curr_path.contains(server_name) && curr_path.contains(CLIENT_PARTIAL_POSTFIX) {
+            let parts = curr_path.as_str().split("_");
+            let parts: Vec<&str> = parts.collect();
+            println!("Found potential: {}", curr_path);
+
+            // get socket id number at the end of the socket path indicating its unique id
+            // This value should never be none
+            let client_id = match parts.last().unwrap().parse::<u8>() {
+                Ok(id) => id,
+                Err(e) => {
+                    println!("Error parsing id from client socket path: {e}");
+                    continue;
+                }
+            };
+            // If the found client id is greater then the current max then
+            // change the max to the client id plus one
+            if client_id >= max {
+                max = client_id + 1;
+            }
+        }
+    }
+
+    // This formatted string gives "/tmp/fifo_socket_<server_name>_client_#"
+    // where # is the unique id for the client socket.
+    let new_socket_path = format!("{}{}{}{}",
+        SOCKET_PATH_PREPEND,
+        server_name,
+        CLIENT_PARTIAL_POSTFIX,
+        max
+    );
+    Ok(new_socket_path)
+}
+
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::time::Duration;
+    use std::thread::sleep;
+    #[test]
+    fn test_gen_client_path() {
+        let _ = File::create("/tmp/fifo_socket_TEST_client_20").unwrap();
+        let socket_client_21 = gen_client_socket_path(&String::from("TEST")).unwrap();
+        // Create a string that should be the same as the path string created by
+        // gen_client_socket_path function.
+        let dummy_client_21_string = String::from("/tmp/fifo_socket_TEST_client_21");
+        assert!(socket_client_21 == dummy_client_21_string);
+        // Clean up after testing is done
+        fs::remove_file("/tmp/fifo_socket_TEST_client_20").unwrap();
+
+    }
+
+    #[test]
+    fn test_client_socket_drop() {
+        {
+            let _ = IpcClient::new("TEST".to_string());
+            // test to ensure file is created
+        }
+        assert!(!(fs::exists("/tmp/fifo_socket_TEST_client_1").unwrap()));
+    }
+
+    #[test]
+    fn test_server_switching_client_addr() {
+        let mut server = IpcServer::new("TEST".to_string()).unwrap();
+        let mut client_1 = IpcClient::new("TEST".to_string()).unwrap();
+        let mut client_2 = IpcClient::new("TEST".to_string()).unwrap();
+
+        client_1.send("dummy_data".as_bytes()).unwrap();
+        // Sleep a small amount of time for server to recv data
+        sleep(Duration::from_millis(5));
+        let mut buf = [0; 50];
+        server.read(&mut buf).unwrap();
+        // Check to see that client_addr has changed successfully to client_1's socket_path
+        println!("client_addr: {} | socket_path: {}", 
+            server.client_addr.unwrap().path().unwrap().to_str().unwrap(),
+            client_1.socket_path
+        );
+        assert_eq!(server.client_addr.unwrap().path().unwrap().to_str().unwrap(), client_1.socket_path);
+        client_2.send("dummy_data2".as_bytes()).unwrap();
+        sleep(Duration::from_millis(5));
+        server.read(&mut buf).unwrap();
+        // Check to see that client_addr has changed successfully to client_2's socket path
+        println!("client_addr: {} | socket_path: {}", 
+            server.client_addr.unwrap().path().unwrap().to_str().unwrap(),
+            client_2.socket_path
+        );
+        assert_eq!(server.client_addr.unwrap().path().unwrap().to_str().unwrap(), client_2.socket_path);
+    }
 }


### PR DESCRIPTION
In regards to [#48](https://github.com/AlbertaSat/ex3_software/issues/48)
In this PR I converted our IPC library to use datagram sockets rather then sequenced packets. During this rewrite I implemented the Interface trait for IpcServer and IpcClient structs, wrote unit tests, and made minor changes to flight software files so that it uses the send function rather then the ipc_write which is incompatible with the new IPC library.  I also changed the Ipc socket in the coms handler responsible for passing commands to the message dispatcher to a client Ipc socket, and therefore the command dispatcher's client for recv command is now a server, this is because clients should be the first ones to talk to a server and not the other way around. There still exists a minor issue with not being able to clean up socket files in the /tmp directory without manually removing them, @rcunrau gave me some options to accomplish this and will be applied in the future most likely using systemd to cleanup sockets.

I am open to all feedback.


