### PR TITLE
removed libudev insal and apt-get command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: install libudev
-        run: sudo apt-get install libudev-dev
       - name: build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
removed two lines from the build file in the workflow that installs the linux package called libudev-dev.